### PR TITLE
Upgrade to Toolkit 0.3.0, upgrade nuget packages, and switch to a new extension runner

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,18 +5,18 @@
   <ItemGroup>
     <PackageVersion Include="AudioSwitcher.AudioApi" Version="4.0.0-alpha5" />
     <PackageVersion Include="AudioSwitcher.AudioApi.CoreAudio" Version="4.0.0-alpha5" />
-    <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="0.0.2" />
-    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.1.0" />
+    <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="0.3.0-preview.3" />
+    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3351.48" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.46-beta" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.250205002" />
-    <PackageVersion Include="Serilog" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="Shmuelie.WinRTServer" Version="2.1.1" />
+    <PackageVersion Include="Shmuelie.WinRTServer" Version="2.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.8" />
   </ItemGroup>
 </Project>

--- a/src/MediaControlsExtension/Program.cs
+++ b/src/MediaControlsExtension/Program.cs
@@ -4,9 +4,7 @@
 // 
 // ------------------------------------------------------------
 
-using System.Diagnostics;
-using Shmuelie.WinRTServer;
-using Shmuelie.WinRTServer.CsWinRT;
+using JPSoftworks.CommandPalette.Extensions.Toolkit;
 
 namespace JPSoftworks.MediaControlsExtension;
 
@@ -15,34 +13,14 @@ internal static class Program
     [MTAThread]
     public static async Task Main(string[] args)
     {
-        Logger.Initialize("JPSoftworks", "MediaControlsExtension");
-
-        if (args.Length > 0 && args[0] == "-RegisterProcessAsComServer")
+        await ExtensionHostRunner.RunAsync(args, new()
         {
-            // Run with low priority
-            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.Idle;
-            // This is a workaround for the process efficiency mode issue in Windows 11.
-            EfficiencyModeHelper.TryEnableProcessEfficiencyMode();
-
-            ComServer server = new();
-            ManualResetEvent extensionDisposedEvent = new(false);
-
-            // We are instantiating an extension instance once above, and returning it every time the callback in RegisterExtension below is called.
-            // This makes sure that only one instance of SampleExtension is alive, which is returned every time the host asks for the IExtension object.
-            // If you want to instantiate a new instance each time the host asks, create the new instance inside the delegate.
-            MediaControlsExtension extensionInstance = new(extensionDisposedEvent);
-            server.RegisterClass<MediaControlsExtension, IExtension>(() => extensionInstance);
-            server.Start();
-
-            // This will make the main thread wait until the event is signalled by the extension class.
-            // Since we have single instance of the extension object, we exit as soon as it is disposed.
-            extensionDisposedEvent.WaitOne();
-
-            server.UnsafeDispose();
-        }
-        else
-        {
-            await StartupHelper.HandleDirectLaunchAsync();
-        }
+            PublisherMoniker = "JPSoftworks",
+            ProductMoniker = "MediaControlsExtension",
+            EnableEfficiencyMode = true,
+            ExtensionFactories = [
+                new DelegateExtensionFactory(extensionDisposedEvent => new MediaControlsExtension(extensionDisposedEvent))
+                ]
+        });
     }
 }


### PR DESCRIPTION
Upgraded NuGet Packages
- JPSoftworks.CommandPalette.Extensions.Toolkit: 0.0.2 → 0.3.0-preview.3
- Microsoft.CommandPalette.Extensions: 0.1.0 → 0.2.0
- Microsoft.Web.WebView2: 1.0.2903.40 → 1.0.3351.48
- Microsoft.WindowsAppSDK: 1.6.250205002 → 1.7.250606001
- Serilog: 4.2.0 → 4.3.0
- Shmuelie.WinRTServer: 2.1.1 → 2.2.1
- System.Text.Json: 9.0.3 → 9.0.8

Closes: #3 