### PR TITLE
Add support for pinning the media player as a band

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="AudioSwitcher.AudioApi" Version="4.0.0-alpha5" />
     <PackageVersion Include="AudioSwitcher.AudioApi.CoreAudio" Version="4.0.0-alpha5" />
-    <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="0.3.0-preview.3" />
+    <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="0.5.0" />
     <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.8.260126002-experimental" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3351.48" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="AudioSwitcher.AudioApi" Version="4.0.0-alpha5" />
     <PackageVersion Include="AudioSwitcher.AudioApi.CoreAudio" Version="4.0.0-alpha5" />
     <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="0.5.0" />
-    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.8.260126002-experimental" />
+    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.9.260204002-experimental" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3351.48" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.46-beta" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="AudioSwitcher.AudioApi" Version="4.0.0-alpha5" />
     <PackageVersion Include="AudioSwitcher.AudioApi.CoreAudio" Version="4.0.0-alpha5" />
     <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="0.3.0-preview.3" />
-    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.2.0" />
+    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.8.260126002-experimental" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3351.48" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.46-beta" />

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackMuteCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackMuteCommandItem.cs
@@ -17,6 +17,7 @@ internal sealed partial class FallbackMuteCommandItem : FallbackCommandItem
     ]);
 
     public FallbackMuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Mute, "com.jpsoftworks.cmdpal.mediacontrols.mute")
+    //public FallbackMuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Mute)
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(true, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackMuteCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackMuteCommandItem.cs
@@ -17,7 +17,6 @@ internal sealed partial class FallbackMuteCommandItem : FallbackCommandItem
     ]);
 
     public FallbackMuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Mute, "com.jpsoftworks.cmdpal.mediacontrols.mute")
-    //public FallbackMuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Mute)
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(true, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackMuteCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackMuteCommandItem.cs
@@ -16,7 +16,7 @@ internal sealed partial class FallbackMuteCommandItem : FallbackCommandItem
         new("vol", "Volume Mute"),
     ]);
 
-    public FallbackMuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Mute)
+    public FallbackMuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Mute, "com.jpsoftworks.cmdpal.mediacontrols.mute")
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(true, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackPlayCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackPlayCommandItem.cs
@@ -17,7 +17,7 @@ internal sealed partial class FallbackPlayCommandItem : FallbackCommandItem
         new("media", "Media Controls: Play/Pause"),
     ]);
 
-    public FallbackPlayCommandItem(ICommand command, string displayTitle, SettingsManager settingsManager) : base(command, displayTitle)
+    public FallbackPlayCommandItem(ICommand command, string displayTitle, SettingsManager settingsManager) : base(command, displayTitle, "com.jpsoftworks.cmdpal.mediacontrols.play")
     {
         this._settingsManager = settingsManager;
         this._command = (PlayPauseMediaCommand)command;

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackPlayCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackPlayCommandItem.cs
@@ -18,7 +18,6 @@ internal sealed partial class FallbackPlayCommandItem : FallbackCommandItem
     ]);
 
     public FallbackPlayCommandItem(ICommand command, string displayTitle, SettingsManager settingsManager) : base(command, displayTitle, "com.jpsoftworks.cmdpal.mediacontrols.play")
-    //public FallbackPlayCommandItem(ICommand command, string displayTitle, SettingsManager settingsManager) : base(command, displayTitle)
     {
         this._settingsManager = settingsManager;
         this._command = (PlayPauseMediaCommand)command;

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackPlayCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackPlayCommandItem.cs
@@ -18,6 +18,7 @@ internal sealed partial class FallbackPlayCommandItem : FallbackCommandItem
     ]);
 
     public FallbackPlayCommandItem(ICommand command, string displayTitle, SettingsManager settingsManager) : base(command, displayTitle, "com.jpsoftworks.cmdpal.mediacontrols.play")
+    //public FallbackPlayCommandItem(ICommand command, string displayTitle, SettingsManager settingsManager) : base(command, displayTitle)
     {
         this._settingsManager = settingsManager;
         this._command = (PlayPauseMediaCommand)command;

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackPreviousTrackCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackPreviousTrackCommandItem.cs
@@ -22,7 +22,7 @@ internal sealed partial class FallbackPreviousTrackCommandItem : FallbackCommand
         IAsyncOperation<GlobalSystemMediaTransportControlsSessionManager> getSessionManagerOperation,
         SettingsManager settingsManager,
         YetAnotherHelper yetAnotherHelper)
-        : base(new NoOpCommand(), Strings.Command_PreviousTrack)
+        : base(new NoOpCommand(), Strings.Command_PreviousTrack, "com.jpsoftworks.cmdpal.mediacontrols.previous")
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(getSessionManagerOperation, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackPreviousTrackCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackPreviousTrackCommandItem.cs
@@ -23,7 +23,6 @@ internal sealed partial class FallbackPreviousTrackCommandItem : FallbackCommand
         SettingsManager settingsManager,
         YetAnotherHelper yetAnotherHelper)
         : base(new NoOpCommand(), Strings.Command_PreviousTrack, "com.jpsoftworks.cmdpal.mediacontrols.previous")
-    //: base(new NoOpCommand(), Strings.Command_PreviousTrack)
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(getSessionManagerOperation, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackPreviousTrackCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackPreviousTrackCommandItem.cs
@@ -23,6 +23,7 @@ internal sealed partial class FallbackPreviousTrackCommandItem : FallbackCommand
         SettingsManager settingsManager,
         YetAnotherHelper yetAnotherHelper)
         : base(new NoOpCommand(), Strings.Command_PreviousTrack, "com.jpsoftworks.cmdpal.mediacontrols.previous")
+    //: base(new NoOpCommand(), Strings.Command_PreviousTrack)
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(getSessionManagerOperation, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackSkipTrackCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackSkipTrackCommandItem.cs
@@ -24,7 +24,7 @@ internal sealed partial class FallbackSkipTrackCommandItem : FallbackCommandItem
         IAsyncOperation<GlobalSystemMediaTransportControlsSessionManager> getSessionManagerOperation,
         SettingsManager settingsManager,
         YetAnotherHelper yetAnotherHelper)
-        : base(new NoOpCommand(), Strings.Command_NextTrack)
+        : base(new NoOpCommand(), Strings.Command_NextTrack, "com.jpsoftworks.cmdpal.mediacontrols.next")
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(getSessionManagerOperation, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackSkipTrackCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackSkipTrackCommandItem.cs
@@ -25,7 +25,6 @@ internal sealed partial class FallbackSkipTrackCommandItem : FallbackCommandItem
         SettingsManager settingsManager,
         YetAnotherHelper yetAnotherHelper)
         : base(new NoOpCommand(), Strings.Command_NextTrack, "com.jpsoftworks.cmdpal.mediacontrols.next")
-    //: base(new NoOpCommand(), Strings.Command_NextTrack)
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(getSessionManagerOperation, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackSkipTrackCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackSkipTrackCommandItem.cs
@@ -25,6 +25,7 @@ internal sealed partial class FallbackSkipTrackCommandItem : FallbackCommandItem
         SettingsManager settingsManager,
         YetAnotherHelper yetAnotherHelper)
         : base(new NoOpCommand(), Strings.Command_NextTrack, "com.jpsoftworks.cmdpal.mediacontrols.next")
+    //: base(new NoOpCommand(), Strings.Command_NextTrack)
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(getSessionManagerOperation, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackUnmuteCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackUnmuteCommandItem.cs
@@ -17,6 +17,7 @@ internal sealed partial class FallbackUnmuteCommandItem : FallbackCommandItem
     ]);
 
     public FallbackUnmuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Unmute, "com.jpsoftworks.cmdpal.mediacontrols.unmute")
+    //public FallbackUnmuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Unmute)
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(false, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackUnmuteCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackUnmuteCommandItem.cs
@@ -16,7 +16,7 @@ internal sealed partial class FallbackUnmuteCommandItem : FallbackCommandItem
         new("vol", "Volume Unmute"),
     ]);
 
-    public FallbackUnmuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Unmute)
+    public FallbackUnmuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Unmute, "com.jpsoftworks.cmdpal.mediacontrols.unmute")
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(false, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/Commands/Fallback/FallbackUnmuteCommandItem.cs
+++ b/src/MediaControlsExtension/Commands/Fallback/FallbackUnmuteCommandItem.cs
@@ -17,7 +17,6 @@ internal sealed partial class FallbackUnmuteCommandItem : FallbackCommandItem
     ]);
 
     public FallbackUnmuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Unmute, "com.jpsoftworks.cmdpal.mediacontrols.unmute")
-    //public FallbackUnmuteCommandItem(SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand(), Strings.Command_Unmute)
     {
         this._settingsManager = settingsManager;
         this.Command = this._command = new(false, yetAnotherHelper) { Name = "" };

--- a/src/MediaControlsExtension/JPSoftworks.MediaControlsExtension.csproj
+++ b/src/MediaControlsExtension/JPSoftworks.MediaControlsExtension.csproj
@@ -5,8 +5,8 @@
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<AppxManifest>$(ProjectDir)Package.appxmanifest</AppxManifest>
 
-		<WindowsSdkPackageVersion>10.0.22621.57</WindowsSdkPackageVersion>
-		<TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+		<WindowsSdkPackageVersion>10.0.26100.68-preview</WindowsSdkPackageVersion>
+		<TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
 		<RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>

--- a/src/MediaControlsExtension/MediaCommandsExtensionCommandsProvider.cs
+++ b/src/MediaControlsExtension/MediaCommandsExtensionCommandsProvider.cs
@@ -17,6 +17,7 @@ public sealed partial class MediaControlsExtensionCommandsProvider : CommandProv
     private readonly CommandItem _nowPlayingItem;
     private ICommandItem[] _commands = [];
     private IFallbackCommandItem[]? _fallbackCommands = [];
+    private readonly ICommandItem[] _bands;
 
     public MediaControlsExtensionCommandsProvider()
     {
@@ -32,8 +33,9 @@ public sealed partial class MediaControlsExtensionCommandsProvider : CommandProv
 
         var mediaControlsExtensionPage = new MediaControlsExtensionPage(this._mediaService, this._settingsManager, this._yetAnotherHelper);
         this._mediaControlsPageItem = new(mediaControlsExtensionPage) { Title = this.DisplayName, Subtitle = Strings.MediaControls_Subtitle!, MoreCommands = [new CommandContextItem(this.Settings.SettingsPage!)] };
-        this._nowPlayingItem = new NowPlayingListItem(this._mediaService, this._settingsManager, this._yetAnotherHelper);
-
+        this._nowPlayingItem = new NowPlayingListItem(this._mediaService, this._settingsManager, this._yetAnotherHelper, false);
+        var mediaControlsBand = new MediaControlsExtensionPage(this._mediaService, this._settingsManager, this._yetAnotherHelper, true);
+        this._bands = [new CommandItem(mediaControlsBand) { Title = Strings.Name! }];
         this.UpdateTopLevelCommands();
 
         _ = Task.Run(this.InitializeMediaServiceSafe);
@@ -88,4 +90,9 @@ public sealed partial class MediaControlsExtensionCommandsProvider : CommandProv
     public override ICommandItem[] TopLevelCommands() => this._commands;
 
     public override IFallbackCommandItem[]? FallbackCommands() => this._fallbackCommands;
+
+    public override ICommandItem[]? GetDockBands()
+    {
+        return _bands;
+    }
 }

--- a/src/MediaControlsExtension/Pages/MediaControlsExtensionPage.cs
+++ b/src/MediaControlsExtension/Pages/MediaControlsExtensionPage.cs
@@ -52,7 +52,7 @@ internal sealed partial class MediaControlsExtensionPage : ListPage
         {
             var oldItems = this._items.ToArray();
 
-            List<MediaSourceListItem> mediaSourceListItems = [.. this._mediaService.Sources.Select(mediaSource => new MediaSourceListItem(this._mediaService, mediaSource, this._settingsManager, this._yetAnotherHelper))];
+            List<MediaSourceListItem> mediaSourceListItems = [.. this._mediaService.Sources.Select(mediaSource => new MediaSourceListItem(this._mediaService, mediaSource, this._settingsManager, this._yetAnotherHelper, this._isBandPage))];
             lock (this._refreshLock)
             {
                 this._items = mediaSourceListItems;

--- a/src/MediaControlsExtension/Pages/MediaSourceListItem.cs
+++ b/src/MediaControlsExtension/Pages/MediaSourceListItem.cs
@@ -5,8 +5,6 @@
 // ------------------------------------------------------------
 
 using System.Text;
-using Windows.ApplicationModel.DataTransfer;
-using Windows.Foundation.Collections;
 using Windows.Media;
 
 namespace JPSoftworks.MediaControlsExtension.Pages;
@@ -97,16 +95,14 @@ internal sealed partial class MediaSourceListItem : ListItemBase, IDisposable
         this._asBand = asBand;
 
         this.Command = this._command = new(mediaService, mediaSource, settingsManager, yetAnotherHelper);
-        var f = new FontIconData("x", "y");
-        var d = new Details() { Title = "sad" };
-        this.Details = d;
+
         this.MoreCommands =
         [
             new CommandContextItem(new BringAssociatedAppToFrontCommand(mediaSource)) { RequestedShortcut = Chords.SwitchToApplication, Icon = Icons.SwitchApps },
-            new MyCommandContextItem(new NextTrackInvokableSpecificMediaCommand(mediaService, mediaSource, yetAnotherHelper)) { RequestedShortcut = Chords.NextTrack, Icon = Icons.NextTrackOutline },
-            new MyCommandContextItem(new PreviousTrackInvokableSpecificMediaCommand(mediaService, mediaSource, yetAnotherHelper)) { RequestedShortcut = Chords.PreviousTrack, Icon = Icons.PreviousTrackOutline },
-            new MyCommandContextItem(new ToggleRepeatSpecificMediaCommand(mediaService, mediaSource, yetAnotherHelper)) { RequestedShortcut = Chords.ToggleRepeat, Icon = Icons.ToggleRepeat },
-            new MyCommandContextItem(new ToggleShuffleSpecificMediaCommand(mediaService, mediaSource, yetAnotherHelper)) { RequestedShortcut = Chords.ToggleShuffle, Icon = Icons.ToggleShuffle },
+            new CommandContextItem(new NextTrackInvokableSpecificMediaCommand(mediaService, mediaSource, yetAnotherHelper)) { RequestedShortcut = Chords.NextTrack, Icon = Icons.NextTrackOutline },
+            new CommandContextItem(new PreviousTrackInvokableSpecificMediaCommand(mediaService, mediaSource, yetAnotherHelper)) { RequestedShortcut = Chords.PreviousTrack, Icon = Icons.PreviousTrackOutline },
+            new CommandContextItem(new ToggleRepeatSpecificMediaCommand(mediaService, mediaSource, yetAnotherHelper)) { RequestedShortcut = Chords.ToggleRepeat, Icon = Icons.ToggleRepeat },
+            new CommandContextItem(new ToggleShuffleSpecificMediaCommand(mediaService, mediaSource, yetAnotherHelper)) { RequestedShortcut = Chords.ToggleShuffle, Icon = Icons.ToggleShuffle },
         ];
 
         this.Update(this._mediaSource);
@@ -237,189 +233,5 @@ internal sealed partial class MediaSourceListItem : ListItemBase, IDisposable
         {
             Logger.LogError(ex);
         }
-    }
-}
-
-public partial class MyCommandContextItem : MyCommandItem, ICommandContextItem
-{
-    public virtual bool IsCritical { get; set; }
-
-    public virtual KeyChord RequestedShortcut { get; set; }
-
-    public MyCommandContextItem(ICommand command)
-        : base(command)
-    {
-    }
-
-    public MyCommandContextItem(
-        string title,
-        string subtitle = "",
-        string name = "",
-        Action? action = null,
-        ICommandResult? result = null)
-    {
-        var c = new AnonymousCommand(action);
-        if (!string.IsNullOrEmpty(name))
-        {
-            c.Name = name;
-        }
-
-        if (result is not null)
-        {
-            c.Result = result;
-        }
-
-        Command = c;
-
-        Title = title;
-        Subtitle = subtitle;
-    }
-}
-
-public partial class MyCommandItem : BaseObservable, ICommandItem// , IExtendedAttributesProvider
-{
-    private readonly PropertySet _extendedAttributes = new();
-
-    private ICommand? _command;
-    //private WeakEventListener<CommandItem, object, IPropChangedEventArgs>? _commandListener;
-    private string _title = string.Empty;
-
-    private DataPackage? _dataPackage;
-    private DataPackageView? _dataPackageView;
-
-    public virtual IIconInfo? Icon { get; set; }
-
-    public virtual string Title
-    {
-        get => !string.IsNullOrEmpty(_title) ? _title : _command?.Name ?? string.Empty;
-        set
-        {
-            var oldTitle = Title;
-            _title = value;
-            //if (Title != oldTitle)
-            //{
-            //    OnPropertyChanged();
-            //}
-        }
-    }
-
-    public virtual string Subtitle { get; set; } = string.Empty;
-
-    public virtual ICommand? Command
-    {
-        get => _command;
-        set
-        {
-            if (EqualityComparer<ICommand?>.Default.Equals(value, _command))
-            {
-                return;
-            }
-
-            var oldTitle = Title;
-
-            //if (_commandListener is not null)
-            //{
-            //    _commandListener.Detach();
-            //    _commandListener = null;
-            //}
-
-            _command = value;
-
-            if (value is not null)
-            {
-                //_commandListener = new(this, OnCommandPropertyChanged, listener => value.PropChanged -= listener.OnEvent);
-                //value.PropChanged += _commandListener.OnEvent;
-            }
-
-            //OnPropertyChanged();
-            if (string.IsNullOrEmpty(_title) && oldTitle != Title)
-            {
-                OnPropertyChanged(nameof(Title));
-            }
-        }
-    }
-
-    private void OnCommandPropertyChanged(CommandItem instance, object source, IPropChangedEventArgs args)
-    {
-        // command's name affects Title only if Title wasn't explicitly set
-        if (args.PropertyName == nameof(ICommand.Name) && string.IsNullOrEmpty(_title))
-        {
-            //instance.OnPropertyChanged(nameof(Title));
-        }
-    }
-
-    public virtual IContextItem[] MoreCommands { get; set; } = [];
-
-    public DataPackage? DataPackage
-    {
-        get => _dataPackage;
-        set
-        {
-            _dataPackage = value;
-            _dataPackageView = null;
-            //_extendedAttributes[WellKnownExtensionAttributes.DataPackage] = value?.AsAgile().Get()?.GetView()!;
-            OnPropertyChanged(nameof(DataPackage));
-            OnPropertyChanged(nameof(DataPackageView));
-        }
-    }
-
-    public DataPackageView? DataPackageView
-    {
-        get => _dataPackageView;
-        set
-        {
-            _dataPackage = null;
-            _dataPackageView = value;
-            //_extendedAttributes[WellKnownExtensionAttributes.DataPackage] = value?.AsAgile().Get()!;
-            OnPropertyChanged(nameof(DataPackage));
-            OnPropertyChanged(nameof(DataPackageView));
-        }
-    }
-
-    public MyCommandItem()
-        : this(new NoOpCommand())
-    {
-    }
-
-    public MyCommandItem(ICommand command)
-    {
-        Command = command;
-    }
-
-    public MyCommandItem(ICommandItem other)
-    {
-        Command = other.Command;
-        Subtitle = other.Subtitle;
-        Icon = (IconInfo?)other.Icon;
-        MoreCommands = other.MoreCommands;
-    }
-
-    public MyCommandItem(
-        string title,
-        string subtitle = "",
-        string name = "",
-        Action? action = null,
-        ICommandResult? result = null)
-    {
-        var c = new AnonymousCommand(action);
-        if (!string.IsNullOrEmpty(name))
-        {
-            c.Name = name;
-        }
-
-        if (result is not null)
-        {
-            c.Result = result;
-        }
-
-        Command = c;
-
-        Title = title;
-        Subtitle = subtitle;
-    }
-
-    public IDictionary<string, object> GetProperties()
-    {
-        return _extendedAttributes;
     }
 }

--- a/src/MediaControlsExtension/Pages/MediaSourceListItem.cs
+++ b/src/MediaControlsExtension/Pages/MediaSourceListItem.cs
@@ -47,26 +47,6 @@ internal partial class ListItemBase : ListItem
         }
     }
 
-    public override IIconInfo? Icon
-    {
-        get => base.Icon;
-        set
-        {
-            if (ReferenceEquals(base.Icon, value))
-            {
-                return;
-            }
-
-            if (base.Icon == value || (base.Icon?.Dark?.Icon == value?.Dark?.Icon && base.Icon?.Light?.Icon == value?.Light?.Icon))
-            {
-                return;
-            }
-
-            base.Icon = value;
-            OnPropertyChanged(nameof(Icon));
-        }
-    }
-
     protected ListItemBase(ICommand command) : base(command)
     {
     }
@@ -87,12 +67,14 @@ internal sealed partial class MediaSourceListItem : ListItemBase, IDisposable
     private NiceIconInfo? _lastIcon;
     private MediaSource _mediaSource;
     private bool _disposed;
+    private bool _asBand;
 
     public MediaSourceListItem(
         MediaService mediaService,
         MediaSource mediaSource,
         SettingsManager settingsManager,
-        YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand())
+        YetAnotherHelper yetAnotherHelper,
+        bool asBand) : base(new NoOpCommand())
     {
         ArgumentNullException.ThrowIfNull(mediaService);
         ArgumentNullException.ThrowIfNull(mediaSource);
@@ -109,6 +91,8 @@ internal sealed partial class MediaSourceListItem : ListItemBase, IDisposable
 
         this.Title = Strings.Command_PlayPause!;
         this.Icon = Icons.PlayPause;
+
+        this._asBand = asBand;
 
         this.Command = this._command = new(mediaService, mediaSource, settingsManager, yetAnotherHelper);
 
@@ -140,7 +124,7 @@ internal sealed partial class MediaSourceListItem : ListItemBase, IDisposable
 
     private void UpdateCore(MediaSource mediaSource)
     {
-        this.Title = (mediaSource.IsPlaying ? "▶️ " : "") + mediaSource.Name;
+        this.Title = (mediaSource.IsPlaying && !this._asBand ? "▶️ " : "") + mediaSource.Name;
         this.Subtitle = BuildSubtitle(mediaSource);
         this._command.Name = mediaSource.IsPlaying ? Strings.Command_Pause : Strings.Command_Play;
         this.Tags = BuildTags();

--- a/src/MediaControlsExtension/Pages/MediaSourceListItem.cs
+++ b/src/MediaControlsExtension/Pages/MediaSourceListItem.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 // 
 // Copyright (c) Jiří Polášek. All rights reserved.
 // 
@@ -52,7 +52,7 @@ internal partial class ListItemBase : ListItem
         get => base.Icon;
         set
         {
-            if(ReferenceEquals(base.Icon, value))
+            if (ReferenceEquals(base.Icon, value))
             {
                 return;
             }
@@ -63,6 +63,7 @@ internal partial class ListItemBase : ListItem
             }
 
             base.Icon = value;
+            OnPropertyChanged(nameof(Icon));
         }
     }
 
@@ -140,7 +141,7 @@ internal sealed partial class MediaSourceListItem : ListItemBase, IDisposable
     private void UpdateCore(MediaSource mediaSource)
     {
         this.Title = (mediaSource.IsPlaying ? "▶️ " : "") + mediaSource.Name;
-        this.Subtitle  = BuildSubtitle(mediaSource);
+        this.Subtitle = BuildSubtitle(mediaSource);
         this._command.Name = mediaSource.IsPlaying ? Strings.Command_Pause : Strings.Command_Play;
         this.Tags = BuildTags();
 


### PR DESCRIPTION
<img width="334" height="103" alt="image" src="https://github.com/user-attachments/assets/2952cec7-fd91-4d53-afe2-b87fbc411c90" />

Couple things in this change:
* Updating the SDK to the experimental version for band support
* Also updating the version of your own toolkit to the latest version of that (as discussed on Teams)
* then 90% of the rest of the change is just "Am I being presented as a band? Then slightly change my appearance".
  * Things like changing the Title/Subtitle, so that it displays the track name and artist
  * Or getting rid of the text on the playback commands
  * etc
* Removing the `Icon` override in MediaSourceListItem. That was what was supressing the icon updates for me
