### PR TITLE
Improve Dock UX and update to the latest SDK

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="AudioSwitcher.AudioApi" Version="4.0.0-alpha5" />
     <PackageVersion Include="AudioSwitcher.AudioApi.CoreAudio" Version="4.0.0-alpha5" />
     <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="0.5.0" />
-    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.9.260204002-experimental" />
+    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.9.260303001" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3351.48" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.46-beta" />

--- a/src/MediaControlsExtension/Helpers/IconExtensions.cs
+++ b/src/MediaControlsExtension/Helpers/IconExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// ------------------------------------------------------------
-// 
+//
 // Copyright (c) Jiří Polášek. All rights reserved.
-// 
+//
 // ------------------------------------------------------------
 
 namespace JPSoftworks.MediaControlsExtension.Helpers;
@@ -10,12 +10,7 @@ internal static class IconExtensions
 {
     public static bool UpdateIcon(this CommandItem item, IIconInfo? icon)
     {
-        if(ReferenceEquals(icon, item.Icon))
-        {
-            return false;
-        }
-
-        if (item.Icon == icon || (item.Icon?.Dark?.Icon == icon?.Dark?.Icon && item.Icon?.Light?.Icon == icon?.Light?.Icon))
+        if (HasSameIcon(item.Icon, icon))
         {
             return false;
         }
@@ -24,19 +19,44 @@ internal static class IconExtensions
         return true;
     }
 
-    public static bool UpdateIcon(this Command command, IconInfo icon)
+    public static bool UpdateIcon(this Command command, IconInfo? icon)
     {
-        if(ReferenceEquals(icon, command.Icon))
+        if (HasSameIcon(command.Icon, icon))
         {
             return false;
         }
 
-        if (command.Icon == icon || (command.Icon?.Dark?.Icon == icon.Dark?.Icon && command.Icon?.Light?.Icon == icon.Light.Icon))
-        {
-            return false;
-        }
-
-        command.Icon = icon;
+        command.Icon = icon!;
         return true;
+    }
+
+    private static bool HasSameIcon(IIconInfo? left, IIconInfo? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return HasSameIconData(left.Dark, right.Dark) && HasSameIconData(left.Light, right.Light);
+    }
+
+    private static bool HasSameIconData(IIconData? left, IIconData? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return string.Equals(left.Icon, right.Icon, StringComparison.Ordinal) && ReferenceEquals(left.Data, right.Data);
     }
 }

--- a/src/MediaControlsExtension/Helpers/SettingsManager.cs
+++ b/src/MediaControlsExtension/Helpers/SettingsManager.cs
@@ -1,7 +1,7 @@
 ﻿// ------------------------------------------------------------
-// 
+//
 // Copyright (c) Jiří Polášek. All rights reserved.
-// 
+//
 // ------------------------------------------------------------
 
 using System.Diagnostics.CodeAnalysis;
@@ -48,7 +48,7 @@ internal sealed class SettingsManager : JsonSettingsManager
         "", //Strings.Settings_KeepOpen_Subtitle!,
         false
     );
-    
+
     [SuppressMessage("Maintainability", "CA1507:Use nameof to express symbol names", Justification = "Settings key is independent to ensure its compatible")]
     private readonly ToggleSetting _keepOpenSkipTrack = new(
         Namespaced("KeepOpenSkipTrack"),
@@ -94,6 +94,13 @@ internal sealed class SettingsManager : JsonSettingsManager
         "", //"Shows skip commands on the media controls page",
         true);
 
+    [SuppressMessage("Maintainability", "CA1507:Use nameof to express symbol names", Justification = "Settings key is independent to ensure its compatible")]
+    private readonly ToggleSetting _showSkipCommandsInDockBand = new(
+        Namespaced("ShowSkipCommandsInDockBand"),
+        "Show skip track commands in Dock\n    Display “Next” and “Previous Track” in the Dock.",
+        "", //"Shows skip commands on the media controls page",
+        true);
+
     public bool ShowThumbnails => this._showThumbnailsOption.Value;
 
     public GlobalCommandsMode GlobalCommands =>
@@ -119,12 +126,15 @@ internal sealed class SettingsManager : JsonSettingsManager
 
     public bool ShowSkipCommands => _showSkipCommands.Value;
 
+    public bool ShowSkipCommandsInDockBand => _showSkipCommandsInDockBand.Value;
+
     public SettingsManager()
     {
         this.FilePath = SettingsJsonPath();
 
         this.Settings.Add(this._showCurrentMediaAtTopLevel);
         this.Settings.Add(this._showSkipCommands);
+        this.Settings.Add(this._showSkipCommandsInDockBand);
         this.Settings.Add(this._showThumbnailsOption);
         this.Settings.Add(this._keepOpen);
         this.Settings.Add(this._pauseOthersOnPlay);
@@ -134,7 +144,7 @@ internal sealed class SettingsManager : JsonSettingsManager
         //this.Settings.Add(this._keepOpenTogglePlayPauseCurrent);
         //this.Settings.Add(this._keepOpenSkipTrack);
         //this.Settings.Add(this._keepOpenTogglePlayMedia);
-        
+
 
 
         this.LoadSettings();

--- a/src/MediaControlsExtension/Pages/DockHeadItem.cs
+++ b/src/MediaControlsExtension/Pages/DockHeadItem.cs
@@ -16,11 +16,11 @@ internal sealed partial class DockHeadItem : ListItemBase, IDisposable
     private readonly Lock _updateLock = new();
     private readonly IContextItem[] _mediaContextCommands;
 
+    private readonly BringAssociatedAppToFrontCommand _primaryMediaCommand;
+    private readonly NoOpCommand _noOpCommand = new();
+
     private MediaSource? _currentMediaSource;
     private NiceIconInfo? _lastIcon;
-
-    private BringAssociatedAppToFrontCommand _primaryMediaCommand;
-    private NoOpCommand _noOpCommand = new();
 
     public DockHeadItem(MediaService mediaService, SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand())
     {
@@ -89,8 +89,10 @@ internal sealed partial class DockHeadItem : ListItemBase, IDisposable
                 this.Title = "";
                 this.Subtitle = "";
                 this.Icon = Icons.NoMedia;
+                this._lastIcon = null;
                 this.Command = this._noOpCommand;
                 this.MoreCommands = [];
+
             }
             else
             {
@@ -101,8 +103,7 @@ internal sealed partial class DockHeadItem : ListItemBase, IDisposable
                 if (this._lastIcon != iconBuildTask && iconBuildTask?.IconInfo != null)
                 {
                     this._lastIcon = iconBuildTask;
-                    var icon = iconBuildTask.IconInfo;
-                    this.UpdateIcon(icon);
+                    this.UpdateIcon(iconBuildTask.IconInfo);
                 }
 
                 this.Command = this._primaryMediaCommand;

--- a/src/MediaControlsExtension/Pages/DockHeadItem.cs
+++ b/src/MediaControlsExtension/Pages/DockHeadItem.cs
@@ -6,7 +6,7 @@
 
 namespace JPSoftworks.MediaControlsExtension.Pages;
 
-internal sealed partial class NowPlayingListItem : ListItemBase, IDisposable
+internal sealed partial class DockHeadItem : ListItemBase, IDisposable
 {
     private readonly MediaService _mediaService;
     private readonly SettingsManager _settingsManager;
@@ -14,18 +14,19 @@ internal sealed partial class NowPlayingListItem : ListItemBase, IDisposable
 
     private readonly Lock _currentMediaSourceLock = new();
     private readonly Lock _updateLock = new();
-    private readonly MediaCurrentSessionCommand _playPauseCommand;
     private readonly IContextItem[] _mediaContextCommands;
-    private readonly bool _isBandPage;
 
     private MediaSource? _currentMediaSource;
+    private NiceIconInfo? _lastIcon;
 
-    public NowPlayingListItem(MediaService mediaService, SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper, bool asBandPage) : base(new NoOpCommand())
+    private BringAssociatedAppToFrontCommand _primaryMediaCommand;
+    private NoOpCommand _noOpCommand = new();
+
+    public DockHeadItem(MediaService mediaService, SettingsManager settingsManager, YetAnotherHelper yetAnotherHelper) : base(new NoOpCommand())
     {
         ArgumentNullException.ThrowIfNull(mediaService);
         ArgumentNullException.ThrowIfNull(settingsManager);
 
-        this._isBandPage = asBandPage;
         this._mediaService = mediaService;
         this._mediaService.CurrentMediaSourceChanged += this.CurrentMediaSourceChanged;
 
@@ -36,18 +37,24 @@ internal sealed partial class NowPlayingListItem : ListItemBase, IDisposable
         this._updateMediaInfo = new(150, () => this.Update(this._currentMediaSource));
 
         this._mediaContextCommands = [
-            new CommandContextItem(new BringAssociatedAppToFrontCommand(this._mediaService)) { RequestedShortcut = Chords.SwitchToApplication, Icon = Icons.SwitchApps },
+
+            new Separator(),
             new CommandContextItem(new MediaCurrentSessionCommand(this._mediaService, MediaSessionOperations.SkipNextTrack, yetAnotherHelper) { Name = Strings.Command_NextTrack }) { RequestedShortcut = Chords.NextTrack, Icon = Icons.NextTrackOutline},
             new CommandContextItem(new MediaCurrentSessionCommand(this._mediaService, MediaSessionOperations.SkipPreviousTrack, yetAnotherHelper) { Name = Strings.Command_PreviousTrack }) { RequestedShortcut = Chords.PreviousTrack, Icon = Icons.PreviousTrackOutline},
+
+            new Separator(),
             new CommandContextItem(new MediaCurrentSessionCommand(this._mediaService, MediaSessionOperations.ToggleRepeat, yetAnotherHelper) { Name = Strings.Command_ToggleRepeat }) { RequestedShortcut = Chords.ToggleRepeat, Icon = Icons.ToggleRepeat},
             new CommandContextItem(new MediaCurrentSessionCommand(this._mediaService, MediaSessionOperations.ToggleShuffle, yetAnotherHelper) { Name = Strings.Command_ToggleShuffle }) { RequestedShortcut = Chords.ToggleShuffle, Icon = Icons.ToggleShuffle},
 
+            new Separator(),
             new CommandContextItem(new MediaCurrentSessionCommand(this._mediaService, new PlayNextSessionMop(this._settingsManager, this._mediaService), yetAnotherHelper) { Name = Strings.Command_NextApp })  { RequestedShortcut = Chords.NextSession, Icon = Icons.NextApp },
             new CommandContextItem(new MediaCurrentSessionCommand(this._mediaService, new PlayPreviousSessionMop(this._settingsManager, this._mediaService), yetAnotherHelper) { Name = Strings.Command_PreviousApp })  { RequestedShortcut = Chords.PreviousSession, Icon = Icons.PreviousApp },
         ];
 
-        this.Command = this._playPauseCommand = new(this._mediaService, MediaSessionOperations.PlayPauseTrack, yetAnotherHelper, id: "com.jpsoftworks.cmdpal.mediacontrols.nowplaying") { Icon = Icons.NoMedia };
-        this.Title = this._isBandPage ? string.Empty : Strings.Command_PlayPause!;
+        this._primaryMediaCommand = new BringAssociatedAppToFrontCommand(this._mediaService);
+        this.Command = this._noOpCommand;
+
+        this.Title = string.Empty;
         this.UpdateIcon(Icons.PlayPause);
 
         this._updateMediaInfo.Invoke();
@@ -79,55 +86,45 @@ internal sealed partial class NowPlayingListItem : ListItemBase, IDisposable
         {
             if (mediaSource is not { HasProperties: true })
             {
-                this.Title = this._isBandPage ? string.Empty : "Nothing is playing right now";
+                this.Title = "";
+                this.Subtitle = "";
                 this.Icon = Icons.NoMedia;
-                this.Subtitle = this._isBandPage ? string.Empty : "Now playing";
-
-                this._playPauseCommand.Name = this._isBandPage ? string.Empty : Strings.Command_PlayPause;
-                this._playPauseCommand.UpdateIcon(Icons.PlayPause);
-
+                this.Command = this._noOpCommand;
                 this.MoreCommands = [];
             }
             else
             {
-                IconInfo icon;
-                string cmdName;
+                this.Title = mediaSource.Name;
+                this.Subtitle = string.Join(" • ", mediaSource.Artist, mediaSource.ApplicationName);
 
-                if (mediaSource.IsPlaying)
+                var iconBuildTask = BuildIcon(mediaSource, this._settingsManager.ShowThumbnails);
+                if (this._lastIcon != iconBuildTask && iconBuildTask?.IconInfo != null)
                 {
-                    if (mediaSource.Session.GetPlaybackInfo().Controls.IsPauseEnabled)
-                    {
-                        this.Title = this._isBandPage ? string.Empty : $"Pause {mediaSource.Name}";
-                        cmdName = Strings.Command_Pause;
-                    }
-                    else if (mediaSource.Session.GetPlaybackInfo().Controls.IsStopEnabled)
-                    {
-                        this.Title = this._isBandPage ? string.Empty : $"Stop {mediaSource.Name}";
-                        cmdName = Strings.Command_Stop;
-                    }
-                    else
-                    {
-                        this.Title = this._isBandPage ? string.Empty : $"Pause {mediaSource.Name}";
-                        cmdName = Strings.Command_Pause;
-                    }
-
-                    icon = Icons.PauseColorful;
-                    this.Subtitle = this._isBandPage ? string.Empty : StringHelper.JoinNonEmpty(" • ", $"Now playing {mediaSource.Name}", mediaSource.Artist, mediaSource.ApplicationName);
-                }
-                else
-                {
-                    this.Title = this._isBandPage ? string.Empty : $"Play {mediaSource.Name}";
-                    this.Subtitle = this._isBandPage ? string.Empty : StringHelper.JoinNonEmpty(" • ", $"Now playing {mediaSource.Name}", mediaSource.Artist, mediaSource.ApplicationName);
-                    icon = Icons.PlayColorful;
-                    cmdName = Strings.Command_Play;
+                    this._lastIcon = iconBuildTask;
+                    var icon = iconBuildTask.IconInfo;
+                    this.UpdateIcon(icon);
                 }
 
-                this.UpdateIcon(icon);
-                this._playPauseCommand.Name = this._isBandPage ? string.Empty : cmdName;
-                this._playPauseCommand.UpdateIcon(icon);
-
+                this.Command = this._primaryMediaCommand;
                 this.MoreCommands = this._mediaContextCommands;
             }
+        }
+
+        return;
+
+        static NiceIconInfo? BuildIcon(MediaSource mediaSource, bool showThumbnail)
+        {
+            if (showThumbnail && mediaSource.ThumbnailInfo?.Stream != null)
+            {
+                return new(mediaSource.ThumbnailInfo!);
+            }
+
+            if (mediaSource.ApplicationIconPath != null)
+            {
+                return new(mediaSource.ApplicationIconPath);
+            }
+
+            return null;
         }
     }
 

--- a/src/MediaControlsExtension/Pages/ListItemBase.cs
+++ b/src/MediaControlsExtension/Pages/ListItemBase.cs
@@ -1,0 +1,54 @@
+// ------------------------------------------------------------
+//
+// Copyright (c) Jiří Polášek. All rights reserved.
+//
+// ------------------------------------------------------------
+
+namespace JPSoftworks.MediaControlsExtension.Pages;
+
+internal partial class ListItemBase : ListItem
+{
+    public override string Title
+    {
+        get => base.Title;
+        set
+        {
+            if (base.Title != value)
+            {
+                base.Title = value;
+            }
+        }
+    }
+
+    public override string Subtitle
+    {
+        get => base.Subtitle;
+        set
+        {
+            if (base.Subtitle != value)
+            {
+                base.Subtitle = value;
+            }
+        }
+    }
+
+    public override ITag[] Tags
+    {
+        get => base.Tags;
+        set
+        {
+            if (base.Tags != value)
+            {
+                base.Tags = value;
+            }
+        }
+    }
+
+    protected ListItemBase(ICommand command) : base(command)
+    {
+    }
+
+    protected ListItemBase(ICommandItem command) : base(command)
+    {
+    }
+}

--- a/src/MediaControlsExtension/Pages/MediaControlsExtensionPage.cs
+++ b/src/MediaControlsExtension/Pages/MediaControlsExtensionPage.cs
@@ -21,6 +21,7 @@ internal sealed partial class MediaControlsExtensionPage : ListPage, IDisposable
     private readonly ListItem _prevTrackCurrentSessionItem;
     private readonly ListItem _muteCommandItem;
     private List<MediaSourceListItem> _items = [];
+    private IListItem[] _cachedItems = [];
 
     public MediaControlsExtensionPage(
         MediaService mediaService,
@@ -46,18 +47,20 @@ internal sealed partial class MediaControlsExtensionPage : ListPage, IDisposable
         this._mediaService.Initialized += (_, _) =>
         {
             this._isInitialized = true;
-            this.RaiseItemsChanged();
+            this.RebuildAndRaiseIfChanged();
         };
 
         this._mediaService.MediaSourcesChanged += (_, _) =>
         {
-            var oldItems = this._items.ToArray();
-
             List<MediaSourceListItem> mediaSourceListItems = [.. this._mediaService.Sources.Select(mediaSource => new MediaSourceListItem(this._mediaService, mediaSource, this._settingsManager, this._yetAnotherHelper, this._isBandPage))];
+            MediaSourceListItem[] oldItems;
             lock (this._refreshLock)
             {
+                oldItems = [.. this._items];
                 this._items = mediaSourceListItems;
             }
+
+            this.RebuildAndRaiseIfChanged();
 
             _ = Task.Run(() =>
             {
@@ -65,7 +68,6 @@ internal sealed partial class MediaControlsExtensionPage : ListPage, IDisposable
                 {
                     try
                     {
-
                         item.Dispose();
                     }
                     catch (Exception ex)
@@ -121,14 +123,34 @@ internal sealed partial class MediaControlsExtensionPage : ListPage, IDisposable
             this._prevTrackCurrentSessionItem.UpdateIcon(prevTrackCommand.CanExecute() ? Icons.SkipPreviousTrack : Icons.SkipPreviousTrackDisabled);
         }
 
-        // don't refresh items - it causes reset of the selected item
+        this.RebuildAndRaiseIfChanged();
     }
 
-    public override IListItem[] GetItems()
+    /// <summary>
+    /// Rebuilds the items list and raises <see cref="RaiseItemsChanged"/> only when
+    /// the item composition (identity or order) actually changed.
+    /// </summary>
+    private void RebuildAndRaiseIfChanged()
+    {
+        lock (this._refreshLock)
+        {
+            var newItems = this.BuildItems();
+            if (ItemsEqual(this._cachedItems, newItems))
+            {
+                return;
+            }
+
+            this._cachedItems = newItems;
+        }
+
+        this.RaiseItemsChanged();
+    }
+
+    private IListItem[] BuildItems()
     {
         if (this._isBandPage)
         {
-            return this.GetBandItems().ToArray();
+            return [.. this.GetBandItems()];
         }
 
         if (!this._isInitialized)
@@ -137,11 +159,15 @@ internal sealed partial class MediaControlsExtensionPage : ListPage, IDisposable
             return [.. this.GetGlobalCommands()];
         }
 
-        return
-        [
-            ..this.GetGlobalCommands(),
-            ..this._items
-        ];
+        return [.. this.GetGlobalCommands(), .. this._items];
+    }
+
+    public override IListItem[] GetItems()
+    {
+        lock (this._refreshLock)
+        {
+            return this._cachedItems;
+        }
     }
 
     private List<IListItem> GetGlobalCommands()
@@ -188,6 +214,24 @@ internal sealed partial class MediaControlsExtensionPage : ListPage, IDisposable
             }
         }
         return items;
+    }
+
+    private static bool ItemsEqual(IListItem[] a, IListItem[] b)
+    {
+        if (a.Length != b.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < a.Length; i++)
+        {
+            if (!ReferenceEquals(a[i], b[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public void Dispose()

--- a/src/MediaControlsExtension/Pages/MediaControlsExtensionPage.cs
+++ b/src/MediaControlsExtension/Pages/MediaControlsExtensionPage.cs
@@ -1,12 +1,12 @@
 // ------------------------------------------------------------
-// 
+//
 // Copyright (c) Jiří Polášek. All rights reserved.
-// 
+//
 // ------------------------------------------------------------
 
 namespace JPSoftworks.MediaControlsExtension.Pages;
 
-internal sealed partial class MediaControlsExtensionPage : ListPage
+internal sealed partial class MediaControlsExtensionPage : ListPage, IDisposable
 {
     private readonly SettingsManager _settingsManager;
     private readonly YetAnotherHelper _yetAnotherHelper;
@@ -15,10 +15,11 @@ internal sealed partial class MediaControlsExtensionPage : ListPage
     private readonly bool _isBandPage;
 
     private bool _isInitialized;
-    private readonly ListItem? _playPauseCurrentSessionItem;
-    private readonly ListItem? _nextTrackCurrentSessionItem;
-    private readonly ListItem? _prevTrackCurrentSessionItem;
-    private readonly ListItem? _muteCommandItem;
+    private readonly NowPlayingListItem _playPauseCurrentSessionItem;
+    private readonly DockHeadItem? _bandFirstItem;
+    private readonly ListItem _nextTrackCurrentSessionItem;
+    private readonly ListItem _prevTrackCurrentSessionItem;
+    private readonly ListItem _muteCommandItem;
     private List<MediaSourceListItem> _items = [];
 
     public MediaControlsExtensionPage(
@@ -73,8 +74,6 @@ internal sealed partial class MediaControlsExtensionPage : ListPage
                     }
                 }
             });
-
-            this.RaiseItemsChanged();
         };
 
         this._mediaService.CurrentMediaSourceChanged += (_, _) => this.UpdateCurrentMediaItems();
@@ -91,6 +90,9 @@ internal sealed partial class MediaControlsExtensionPage : ListPage
         };
 
         this._playPauseCurrentSessionItem = new NowPlayingListItem(this._mediaService, this._settingsManager, this._yetAnotherHelper, this._isBandPage);
+        this._bandFirstItem = this._isBandPage
+            ? new DockHeadItem(this._mediaService, this._settingsManager, this._yetAnotherHelper)
+            : null;
         this._nextTrackCurrentSessionItem = new(new MediaCurrentSessionCommand(this._mediaService, MediaSessionOperations.SkipNextTrack, this._yetAnotherHelper)) { Title = Strings.Command_NextTrack, Subtitle = Strings.Command_NextTrack_Subtitle, Icon = Icons.SkipNextTrack };
         this._prevTrackCurrentSessionItem = new(new MediaCurrentSessionCommand(this._mediaService, MediaSessionOperations.SkipPreviousTrack, this._yetAnotherHelper)) { Title = Strings.Command_PreviousTrack, Subtitle = Strings.Command_PreviousTrack_Subtitle, Icon = Icons.SkipPreviousTrack };
         this._muteCommandItem = new(new ToggleMuteMediaInvokableCommand(this._yetAnotherHelper));
@@ -110,11 +112,6 @@ internal sealed partial class MediaControlsExtensionPage : ListPage
 
     private void UpdateCurrentMediaItems()
     {
-        if (!this._settingsManager.ShowSkipCommands)
-        {
-            return;
-        }
-
         if (this._nextTrackCurrentSessionItem?.Command is MediaCurrentSessionCommand nextTrackCommand)
         {
             this._nextTrackCurrentSessionItem.UpdateIcon(nextTrackCommand.CanExecute() ? Icons.SkipNextTrack : Icons.SkipNextTrackDisabled);
@@ -166,17 +163,36 @@ internal sealed partial class MediaControlsExtensionPage : ListPage
 
         return items;
     }
+
     private List<IListItem> GetBandItems()
     {
-        List<IListItem> items = [];
-        if (this._playPauseCurrentSessionItem != null && this._items.Count > 0)
+        if (!this._isBandPage || this._bandFirstItem is null)
         {
-            items.Add(this._items.First());
-            items.Add(this._prevTrackCurrentSessionItem!);
+            return [];
+        }
+
+        List<IListItem> items = [];
+
+        items.Add(this._bandFirstItem!);
+
+        if (this._mediaService.CurrentSource is not null)
+        {
+            if (this._settingsManager.ShowSkipCommandsInDockBand)
+            {
+                items.Add(this._prevTrackCurrentSessionItem!);
+            }
             items.Add(this._playPauseCurrentSessionItem);
-            items.Add(this._nextTrackCurrentSessionItem!);
+            if (this._settingsManager.ShowSkipCommandsInDockBand)
+            {
+                items.Add(this._nextTrackCurrentSessionItem!);
+            }
         }
         return items;
     }
 
+    public void Dispose()
+    {
+        this._playPauseCurrentSessionItem?.Dispose();
+        this._bandFirstItem?.Dispose();
+    }
 }

--- a/src/MediaControlsExtension/Pages/MediaSourceListItem.cs
+++ b/src/MediaControlsExtension/Pages/MediaSourceListItem.cs
@@ -9,53 +9,6 @@ using Windows.Media;
 
 namespace JPSoftworks.MediaControlsExtension.Pages;
 
-internal partial class ListItemBase : ListItem
-{
-    public override string Title
-    {
-        get => base.Title;
-        set
-        {
-            if (base.Title != value)
-            {
-                base.Title = value;
-            }
-        }
-    }
-
-    public override string Subtitle
-    {
-        get => base.Subtitle;
-        set
-        {
-            if (base.Subtitle != value)
-            {
-                base.Subtitle = value;
-            }
-        }
-    }
-
-    public override ITag[] Tags
-    {
-        get => base.Tags;
-        set
-        {
-            if (base.Tags != value)
-            {
-                base.Tags = value;
-            }
-        }
-    }
-
-    protected ListItemBase(ICommand command) : base(command)
-    {
-    }
-
-    protected ListItemBase(ICommandItem command) : base(command)
-    {
-    }
-}
-
 internal sealed partial class MediaSourceListItem : ListItemBase, IDisposable
 {
     private static readonly Tag PlayingTag = new() { Text = Strings.Tags_Playing!, Icon = Icons.PlaySolid, Foreground = new(true, new(0, 255, 0, 128)), Background = new(true, new(0, 255, 00, 40)) };


### PR DESCRIPTION
- Shows the current media sessions instead of the first session
- Fixes icon update routine
- Changes the first dock band item command to "Switch to application"
- Adds an option to hide prev/next track dock items
- Hide buttons when there's no media session active

Fixes: #9