### PR TITLE
Improve layout and formatting of the settings page

### DIFF
--- a/src/MediaControlsExtension/Helpers/SettingsGroupHeader.cs
+++ b/src/MediaControlsExtension/Helpers/SettingsGroupHeader.cs
@@ -1,0 +1,52 @@
+// ------------------------------------------------------------
+//
+// Copyright (c) Jiří Polášek. All rights reserved.
+//
+// ------------------------------------------------------------
+
+using System.Text.Json.Nodes;
+
+namespace JPSoftworks.MediaControlsExtension.Helpers;
+
+/// <summary>
+/// A presentation-only settings element that renders an Adaptive Card group header.
+/// </summary>
+internal sealed class SettingsGroupHeader : Setting<string>
+{
+    private readonly bool _showSeparator;
+
+    public SettingsGroupHeader(string key, string title, bool showSeparator = true)
+        : base(key, title)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+
+        this._showSeparator = showSeparator;
+    }
+
+    public override Dictionary<string, object> ToDictionary()
+    {
+        return new()
+        {
+            { "type", "TextBlock" },
+            { "text", this.Value ?? string.Empty },
+            { "weight", "Bolder" },
+            { "size", "Medium" },
+            { "wrap", true },
+            { "separator", this._showSeparator },
+            { "spacing", this._showSeparator ? "Large" : "None" },
+        };
+    }
+
+    public override void Update(JsonObject payload)
+    {
+        // This element is presentation-only and ignores submitted form data.
+    }
+
+    public override string ToState()
+    {
+        // Settings requires every form element to contribute a JSON property.
+        // A stable null entry keeps the pseudo-setting inert without accumulating
+        // random keys in settings.json across extension launches.
+        return $"\"{this.Key}\": null";
+    }
+}

--- a/src/MediaControlsExtension/Helpers/SettingsManager.cs
+++ b/src/MediaControlsExtension/Helpers/SettingsManager.cs
@@ -159,8 +159,8 @@ internal sealed class SettingsManager : JsonSettingsManager
         this.Settings.Add(this._pauseOthersOnPlay);
         this.Settings.Add(this._showToastMessages);
         this.Settings.Add(new SettingsGroupHeader(
-            Namespaced("Layout.GlobalSearch"),
-            Strings.Settings_Group_GlobalSearch!));
+            Namespaced("Layout.Commands"),
+            Strings.Settings_Group_Commands!));
         this.Settings.Add(this._globalCommands);
         this.Settings.Add(this._enableVolumeControls);
         this.Settings.Add(new SettingsGroupHeader(

--- a/src/MediaControlsExtension/Helpers/SettingsManager.cs
+++ b/src/MediaControlsExtension/Helpers/SettingsManager.cs
@@ -15,8 +15,8 @@ internal sealed class SettingsManager : JsonSettingsManager
     [SuppressMessage("Maintainability", "CA1507:Use nameof to express symbol names", Justification = "Settings key is independent to ensure its compatible")]
     private readonly ToggleSetting _showThumbnailsOption = new(
         Namespaced("ShowThumbnails"),
-        Strings.Settings_ShowThumbnails_Title! + Environment.NewLine + Strings.Settings_ShowThumbnails_Subtitle!,
-        "",
+        Strings.Settings_ShowThumbnails_Title!,
+        Strings.Settings_ShowThumbnails_Subtitle!,
         false);
 
 
@@ -36,8 +36,8 @@ internal sealed class SettingsManager : JsonSettingsManager
     [SuppressMessage("Maintainability", "CA1507:Use nameof to express symbol names", Justification = "Settings key is independent to ensure its compatible")]
     private readonly ToggleSetting _keepOpen = new(
         Namespaced("KeepOpen"),
-        Strings.Settings_KeepOpen_Title! + Environment.NewLine + Strings.Settings_KeepOpen_Subtitle!,
-        "",
+        Strings.Settings_KeepOpen_Title!,
+        Strings.Settings_KeepOpen_Subtitle!,
         true
         );
 
@@ -68,44 +68,44 @@ internal sealed class SettingsManager : JsonSettingsManager
     [SuppressMessage("Maintainability", "CA1507:Use nameof to express symbol names", Justification = "Settings key is independent to ensure its compatible")]
     private readonly ToggleSetting _showToastMessages = new(
         Namespaced("ShowToastMessages"),
-        Strings.Settings_ShowToastMessages_Title! + Environment.NewLine + Strings.Settings_ShowToastMessages_Subtitle!,
-        "",
+        Strings.Settings_ShowToastMessages_Title!,
+        Strings.Settings_ShowToastMessages_Subtitle!,
         true
     );
 
     [SuppressMessage("Maintainability", "CA1507:Use nameof to express symbol names", Justification = "Settings key is independent to ensure its compatible")]
     private readonly ToggleSetting _pauseOthersOnPlay = new(
         Namespaced("PauseOthersOnPlay"),
-        Strings.Settings_PauseOthersOnPlay_Title! + Environment.NewLine + Strings.Settings_PauseOthersOnPlay_Subtitle!,
-        "",
+        Strings.Settings_PauseOthersOnPlay_Title!,
+        Strings.Settings_PauseOthersOnPlay_Subtitle!,
         true);
 
     [SuppressMessage("Maintainability", "CA1507:Use nameof to express symbol names", Justification = "Settings key is independent to ensure its compatible")]
     private readonly ToggleSetting _showCurrentMediaAtTopLevel = new(
         Namespaced("ShowCurrentMediaAtTopLevel"),
-        Strings.Settings_ShowCurrentMediaAtTopLevel_Title! + Environment.NewLine + Strings.Settings_ShowCurrentMediaAtTopLevel_Subtitle!,
-        "",
+        Strings.Settings_ShowCurrentMediaAtTopLevel_Title!,
+        Strings.Settings_ShowCurrentMediaAtTopLevel_Subtitle!,
         true);
 
     [SuppressMessage("Maintainability", "CA1507:Use nameof to express symbol names", Justification = "Settings key is independent to ensure its compatible")]
     private readonly ToggleSetting _enableVolumeControls = new(
         Namespaced("EnableVolumeControls"),
-        Strings.Settings_EnableVolumeControls_Title! + Environment.NewLine + Strings.Settings_EnableVolumeControls_Subtitle!,
-        "",
+        Strings.Settings_EnableVolumeControls_Title!,
+        Strings.Settings_EnableVolumeControls_Subtitle!,
         true);
 
     [SuppressMessage("Maintainability", "CA1507:Use nameof to express symbol names", Justification = "Settings key is independent to ensure its compatible")]
     private readonly ToggleSetting _showSkipCommands = new(
         Namespaced("ShowSkipCommands"),
-        Strings.Settings_ShowSkipCommands_Title! + Environment.NewLine + Strings.Settings_ShowSkipCommands_Subtitle!,
-        "",
+        Strings.Settings_ShowSkipCommands_Title!,
+        Strings.Settings_ShowSkipCommands_Subtitle!,
         true);
 
     [SuppressMessage("Maintainability", "CA1507:Use nameof to express symbol names", Justification = "Settings key is independent to ensure its compatible")]
     private readonly ToggleSetting _showSkipCommandsInDockBand = new(
         Namespaced("ShowSkipCommandsInDockBand"),
-        Strings.Settings_ShowSkipCommandsInDock_Title! + Environment.NewLine + Strings.Settings_ShowSkipCommandsInDock_Subtitle!,
-        "",
+        Strings.Settings_ShowSkipCommandsInDock_Title!,
+        Strings.Settings_ShowSkipCommandsInDock_Subtitle!,
         true);
 
     public bool ShowThumbnails => this._showThumbnailsOption.Value;
@@ -141,15 +141,38 @@ internal sealed class SettingsManager : JsonSettingsManager
     {
         this.FilePath = SettingsJsonPath();
 
+        this.Settings.Add(new SettingsGroupHeader(
+            Namespaced("Layout.PalettePage"),
+            Strings.Settings_Group_PalettePage!,
+            showSeparator: false));
         this.Settings.Add(this._showCurrentMediaAtTopLevel);
         this.Settings.Add(this._showSkipCommands);
+        this.Settings.Add(new SettingsGroupHeader(
+            Namespaced("Layout.Dock"),
+            Strings.Settings_Group_Dock!));
         this.Settings.Add(this._showSkipCommandsInDockBand);
+        this.Settings.Add(new SettingsGroupHeader(
+            Namespaced("Layout.CommandBehavior"),
+            Strings.Settings_Group_AppearanceAndBehavior!));
         this.Settings.Add(this._showThumbnailsOption);
         this.Settings.Add(this._keepOpen);
         this.Settings.Add(this._pauseOthersOnPlay);
         this.Settings.Add(this._showToastMessages);
+        this.Settings.Add(new SettingsGroupHeader(
+            Namespaced("Layout.GlobalSearch"),
+            Strings.Settings_Group_GlobalSearch!));
         this.Settings.Add(this._globalCommands);
         this.Settings.Add(this._enableVolumeControls);
+        this.Settings.Add(new SettingsGroupHeader(
+            Namespaced("Layout.HelpAndAcknowledgements"),
+            Strings.Settings_Group_HelpAndAcknowledgements!));
+        this.Settings.Add(new TextBlockSetting(
+            Namespaced("Layout.Help"),
+            Strings.Settings_Help!));
+        this.Settings.Add(new TextBlockSetting(
+            Namespaced("Layout.Acknowledgements"),
+            Strings.Settings_Acknowledgements!,
+            isSubtle: true));
 
         //this.Settings.Add(this._keepOpenTogglePlayPauseCurrent);
         //this.Settings.Add(this._keepOpenSkipTrack);

--- a/src/MediaControlsExtension/Helpers/TextBlockSetting.cs
+++ b/src/MediaControlsExtension/Helpers/TextBlockSetting.cs
@@ -1,0 +1,47 @@
+// ------------------------------------------------------------
+//
+// Copyright (c) Jiří Polášek. All rights reserved.
+//
+// ------------------------------------------------------------
+
+using System.Text.Json.Nodes;
+
+namespace JPSoftworks.MediaControlsExtension.Helpers;
+
+/// <summary>
+/// A presentation-only settings element that renders formatted Adaptive Card text.
+/// </summary>
+internal sealed class TextBlockSetting : Setting<string>
+{
+    private readonly bool _isSubtle;
+
+    public TextBlockSetting(string key, string text, bool isSubtle = false)
+        : base(key, text)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(text);
+
+        this._isSubtle = isSubtle;
+    }
+
+    public override Dictionary<string, object> ToDictionary()
+    {
+        return new()
+        {
+            { "type", "TextBlock" },
+            { "text", this.Value ?? string.Empty },
+            { "isSubtle", this._isSubtle },
+            { "wrap", true },
+        };
+    }
+
+    public override void Update(JsonObject payload)
+    {
+        // This element is presentation-only and ignores submitted form data.
+    }
+
+    public override string ToState()
+    {
+        // Settings requires every form element to contribute a JSON property.
+        return $"\"{this.Key}\": null";
+    }
+}

--- a/src/MediaControlsExtension/Resources/Strings.Designer.cs
+++ b/src/MediaControlsExtension/Resources/Strings.Designer.cs
@@ -434,20 +434,20 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Commands.
+        /// </summary>
+        internal static string Settings_Group_Commands {
+            get {
+                return ResourceManager.GetString("Settings_Group_Commands", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Dock.
         /// </summary>
         internal static string Settings_Group_Dock {
             get {
                 return ResourceManager.GetString("Settings_Group_Dock", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Global search.
-        /// </summary>
-        internal static string Settings_Group_GlobalSearch {
-            get {
-                return ResourceManager.GetString("Settings_Group_GlobalSearch", resourceCulture);
             }
         }
         

--- a/src/MediaControlsExtension/Resources/Strings.Designer.cs
+++ b/src/MediaControlsExtension/Resources/Strings.Designer.cs
@@ -167,7 +167,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_SetVolume", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Stop.
         /// </summary>
@@ -239,7 +239,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_VolumeDown", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Volume up.
         /// </summary>
@@ -248,7 +248,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_VolumeUp", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No media sources are currently available. Please ensure that you have media applications running that support media controls..
         /// </summary>
@@ -358,6 +358,19 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Created by [Jiří Polášek](https://jiripolasek.com)
+        ///_Licensed under the Apache 2.0 license_
+        ///_Copyright © Jiří Polášek_
+        ///
+        ///Special thanks to [Mike Griese](https://github.com/zadjii-msft).
+        /// </summary>
+        internal static string Settings_Acknowledgements {
+            get {
+                return ResourceManager.GetString("Settings_Acknowledgements", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show this extension&apos;s system volume commands. Turn this off if another extension already provides them..
         /// </summary>
         internal static string Settings_EnableVolumeControls_Subtitle {
@@ -365,7 +378,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_EnableVolumeControls_Subtitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Enable volume controls.
         /// </summary>
@@ -374,7 +387,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_EnableVolumeControls_Title", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Disabled.
         /// </summary>
@@ -394,7 +407,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Controls additional media controls commands in the global search.
+        ///   Looks up a localized string similar to Show additional Media Controls commands in global search results..
         /// </summary>
         internal static string Settings_GlobalCommands_Subtitle {
             get {
@@ -403,11 +416,65 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Global Commands.
+        ///   Looks up a localized string similar to Additional global commands.
         /// </summary>
         internal static string Settings_GlobalCommands_Title {
             get {
                 return ResourceManager.GetString("Settings_GlobalCommands_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Appearance and behavior.
+        /// </summary>
+        internal static string Settings_Group_AppearanceAndBehavior {
+            get {
+                return ResourceManager.GetString("Settings_Group_AppearanceAndBehavior", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dock.
+        /// </summary>
+        internal static string Settings_Group_Dock {
+            get {
+                return ResourceManager.GetString("Settings_Group_Dock", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Global search.
+        /// </summary>
+        internal static string Settings_Group_GlobalSearch {
+            get {
+                return ResourceManager.GetString("Settings_Group_GlobalSearch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Help and acknowledgements.
+        /// </summary>
+        internal static string Settings_Group_HelpAndAcknowledgements {
+            get {
+                return ResourceManager.GetString("Settings_Group_HelpAndAcknowledgements", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Command Palette page.
+        /// </summary>
+        internal static string Settings_Group_PalettePage {
+            get {
+                return ResourceManager.GetString("Settings_Group_PalettePage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Get help, report a problem, or view the source code](https://github.com/jiripolasek/MediaControlsExtension).
+        /// </summary>
+        internal static string Settings_Help {
+            get {
+                return ResourceManager.GetString("Settings_Help", resourceCulture);
             }
         }
         
@@ -439,8 +506,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Keep the Command Palette open after running a command, so you can perform multiple actions in a row.
-        ///Hold Shift while activating a command to temporarily do the opposite..
+        ///   Looks up a localized string similar to Run multiple media commands in sequence without reopening Command Palette. Hold Shift while running a command to temporarily reverse this behavior..
         /// </summary>
         internal static string Settings_KeepOpen_Subtitle {
             get {
@@ -449,7 +515,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Keep Command Palette open.
+        ///   Looks up a localized string similar to Keep Command Palette open after a command.
         /// </summary>
         internal static string Settings_KeepOpen_Title {
             get {
@@ -467,7 +533,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pause other sessions on play.
+        ///   Looks up a localized string similar to Pause other sessions when playback starts.
         /// </summary>
         internal static string Settings_PauseOthersOnPlay_Title {
             get {
@@ -476,7 +542,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Adds a “Now Playing” item to the home page for easy access to the current session..
+        ///   Looks up a localized string similar to Add a “Now Playing” item for quick access to the current media session..
         /// </summary>
         internal static string Settings_ShowCurrentMediaAtTopLevel_Subtitle {
             get {
@@ -485,7 +551,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show current media session on home page.
+        ///   Looks up a localized string similar to Show the current media session on the home page.
         /// </summary>
         internal static string Settings_ShowCurrentMediaAtTopLevel_Title {
             get {
@@ -494,7 +560,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Display “Next Track” and “Previous Track” as top-level items on the Media Controls page..
+        ///   Looks up a localized string similar to Display “Next Track” and “Previous Track” on the Media Controls page..
         /// </summary>
         internal static string Settings_ShowSkipCommands_Subtitle {
             get {
@@ -503,7 +569,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show skip track commands.
+        ///   Looks up a localized string similar to Show track navigation commands.
         /// </summary>
         internal static string Settings_ShowSkipCommands_Title {
             get {
@@ -521,7 +587,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show skip track commands in Dock.
+        ///   Looks up a localized string similar to Show track navigation commands.
         /// </summary>
         internal static string Settings_ShowSkipCommandsInDock_Title {
             get {
@@ -548,7 +614,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show a confirmation notification after each media action..
+        ///   Looks up a localized string similar to Show a notification after each media action..
         /// </summary>
         internal static string Settings_ShowToastMessages_Subtitle {
             get {
@@ -557,7 +623,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show toast messages.
+        ///   Looks up a localized string similar to Show action confirmations.
         /// </summary>
         internal static string Settings_ShowToastMessages_Title {
             get {
@@ -654,7 +720,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_MediaControlsUnavailable", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Muted.
         /// </summary>
@@ -843,7 +909,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_Volume", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Toggle Play / Pause.
         /// </summary>
@@ -861,7 +927,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("TogglePlayPause_Comments", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0}%.
         /// </summary>
@@ -870,7 +936,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Volume_Level", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Volume - {0} %.
         /// </summary>
@@ -879,7 +945,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Volume_Status", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Volume - muted.
         /// </summary>

--- a/src/MediaControlsExtension/Resources/Strings.resx
+++ b/src/MediaControlsExtension/Resources/Strings.resx
@@ -199,10 +199,10 @@
     <value>Manage playback and switch between media apps with ease</value>
   </data>
   <data name="Settings_GlobalCommands_Title" xml:space="preserve">
-    <value>Global Commands</value>
+    <value>Additional global commands</value>
   </data>
   <data name="Settings_GlobalCommands_Subtitle" xml:space="preserve">
-    <value>Controls additional media controls commands in the global search</value>
+    <value>Show additional Media Controls commands in global search results.</value>
   </data>
   <data name="Settings_GlobalCommands_Option_Enabled" xml:space="preserve">
     <value>Enabled</value>
@@ -211,11 +211,10 @@
     <value>Disabled</value>
   </data>
   <data name="Settings_KeepOpen_Title" xml:space="preserve">
-    <value>Keep Command Palette open</value>
+    <value>Keep Command Palette open after a command</value>
   </data>
   <data name="Settings_KeepOpen_Subtitle" xml:space="preserve">
-    <value>Keep the Command Palette open after running a command, so you can perform multiple actions in a row.
-Hold Shift while activating a command to temporarily do the opposite.</value>
+    <value>Run multiple media commands in sequence without reopening Command Palette. Hold Shift while running a command to temporarily reverse this behavior.</value>
   </data>
   <data name="Command_Play" xml:space="preserve">
     <value>Play</value>
@@ -350,25 +349,25 @@ Hold Shift while activating a command to temporarily do the opposite.</value>
     <value>Playing {0}</value>
   </data>
   <data name="Settings_ShowToastMessages_Title" xml:space="preserve">
-    <value>Show toast messages</value>
+    <value>Show action confirmations</value>
   </data>
   <data name="Settings_ShowToastMessages_Subtitle" xml:space="preserve">
-    <value>Show a confirmation notification after each media action.</value>
+    <value>Show a notification after each media action.</value>
   </data>
   <data name="Settings_PauseOthersOnPlay_Title" xml:space="preserve">
-    <value>Pause other sessions on play</value>
+    <value>Pause other sessions when playback starts</value>
   </data>
   <data name="Settings_PauseOthersOnPlay_Subtitle" xml:space="preserve">
     <value>When playing a session, automatically pause all other sessions.</value>
   </data>
   <data name="Settings_ShowCurrentMediaAtTopLevel_Title" xml:space="preserve">
-    <value>Show current media session on home page</value>
+    <value>Show the current media session on the home page</value>
   </data>
   <data name="Settings_ShowCurrentMediaAtTopLevel_Subtitle" xml:space="preserve">
-    <value>Adds a &#x201C;Now Playing&#x201D; item to the home page for easy access to the current session.</value>
+    <value>Add a &#x201C;Now Playing&#x201D; item for quick access to the current media session.</value>
   </data>
   <data name="Settings_ShowSkipCommands_Title" xml:space="preserve">
-    <value>Show skip track commands</value>
+    <value>Show track navigation commands</value>
   </data>
   <data name="Settings_EnableVolumeControls_Title" xml:space="preserve">
     <value>Enable volume controls</value>
@@ -377,13 +376,38 @@ Hold Shift while activating a command to temporarily do the opposite.</value>
     <value>Show this extension's system volume commands. Turn this off if another extension already provides them.</value>
   </data>
   <data name="Settings_ShowSkipCommands_Subtitle" xml:space="preserve">
-    <value>Display &#x201C;Next Track&#x201D; and &#x201C;Previous Track&#x201D; as top-level items on the Media Controls page.</value>
+    <value>Display &#x201C;Next Track&#x201D; and &#x201C;Previous Track&#x201D; on the Media Controls page.</value>
   </data>
   <data name="Settings_ShowSkipCommandsInDock_Title" xml:space="preserve">
-    <value>Show skip track commands in Dock</value>
+    <value>Show track navigation commands</value>
   </data>
   <data name="Settings_ShowSkipCommandsInDock_Subtitle" xml:space="preserve">
     <value>Display &#x201C;Next Track&#x201D; and &#x201C;Previous Track&#x201D; in the Dock.</value>
+  </data>
+  <data name="Settings_Group_PalettePage" xml:space="preserve">
+    <value>Command Palette page</value>
+  </data>
+  <data name="Settings_Group_Dock" xml:space="preserve">
+    <value>Dock</value>
+  </data>
+  <data name="Settings_Group_AppearanceAndBehavior" xml:space="preserve">
+    <value>Appearance and behavior</value>
+  </data>
+  <data name="Settings_Group_GlobalSearch" xml:space="preserve">
+    <value>Global search</value>
+  </data>
+  <data name="Settings_Group_HelpAndAcknowledgements" xml:space="preserve">
+    <value>Help and acknowledgements</value>
+  </data>
+  <data name="Settings_Help" xml:space="preserve">
+    <value>[Get help, report a problem, or view the source code](https://github.com/jiripolasek/MediaControlsExtension)</value>
+  </data>
+  <data name="Settings_Acknowledgements" xml:space="preserve">
+    <value>Created by [Jiří Polášek](https://jiripolasek.com)
+_Licensed under the Apache 2.0 license_
+_Copyright © Jiří Polášek_
+
+Special thanks to [Mike Griese](https://github.com/zadjii-msft)</value>
   </data>
   <data name="Settings_HideAfterPlayPause" xml:space="preserve">
     <value>Hide after Play/Pause</value>

--- a/src/MediaControlsExtension/Resources/Strings.resx
+++ b/src/MediaControlsExtension/Resources/Strings.resx
@@ -393,8 +393,8 @@
   <data name="Settings_Group_AppearanceAndBehavior" xml:space="preserve">
     <value>Appearance and behavior</value>
   </data>
-  <data name="Settings_Group_GlobalSearch" xml:space="preserve">
-    <value>Global search</value>
+  <data name="Settings_Group_Commands" xml:space="preserve">
+    <value>Commands</value>
   </data>
   <data name="Settings_Group_HelpAndAcknowledgements" xml:space="preserve">
     <value>Help and acknowledgements</value>


### PR DESCRIPTION
This PR improves formatting of settings page, separate options into sections, adds like to help and support.

<img width="1600" height="2001" alt="image" src="https://github.com/user-attachments/assets/ddff05dd-96ff-417e-80d1-114cc502b3b1" />
