### PR TITLE
Harden GSMTC refresh handling and add detailed logging

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-      <ToolkitVersion>0.9.3-preview.1</ToolkitVersion>
+      <ToolkitVersion>0.9.3-preview.2</ToolkitVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="$(ToolkitVersion)" />

--- a/src/MediaControlsExtension.Media/Diagnostics/MediaLog.cs
+++ b/src/MediaControlsExtension.Media/Diagnostics/MediaLog.cs
@@ -117,4 +117,81 @@ internal static partial class MediaLog
         string applicationId,
         string observationPart,
         Exception exception);
+
+    [LoggerMessage(EventId = 20, Level = LogLevel.Debug, Message = "Media refresh #{RefreshId} is starting in {Mode} mode after coalescing {RequestCount} request(s) ({Reasons}); burst credits: {BurstCredits}, topology credits: {TopologyBurstCredits}.")]
+    public static partial void RefreshStarting(
+        ILogger logger,
+        long refreshId,
+        MediaRefreshMode mode,
+        int requestCount,
+        MediaRefreshReason reasons,
+        int burstCredits,
+        int topologyBurstCredits);
+
+    [LoggerMessage(EventId = 21, Level = LogLevel.Debug, Message = "Media refresh #{RefreshId} completed in {Elapsed}; sessions: {SessionCount}, current session: {CurrentSessionId}, status: {Status}.")]
+    public static partial void RefreshCompleted(
+        ILogger logger,
+        long refreshId,
+        TimeSpan elapsed,
+        int sessionCount,
+        long? currentSessionId,
+        MediaServiceStatus status);
+
+    [LoggerMessage(EventId = 22, Level = LogLevel.Trace, Message = "GSMTC delivered {PlaybackSignals} playback, {TimelineSignals} timeline, {MediaSignals} media, {SessionsSignals} sessions, and {CurrentSignals} current-session notification(s) before this snapshot.")]
+    public static partial void NativeSignalsDrained(
+        ILogger logger,
+        long playbackSignals,
+        long timelineSignals,
+        long mediaSignals,
+        long sessionsSignals,
+        long currentSignals);
+
+    [LoggerMessage(EventId = 23, Level = LogLevel.Trace, Message = "GSMTC native call #{CallId} {Operation} is starting for session {SessionId}/{BindingGeneration} ({ApplicationId}).")]
+    public static partial void NativeCallStarting(
+        ILogger logger,
+        long callId,
+        string operation,
+        long sessionId,
+        long bindingGeneration,
+        string applicationId);
+
+    [LoggerMessage(EventId = 24, Level = LogLevel.Trace, Message = "GSMTC native call #{CallId} {Operation} completed in {Elapsed} for session {SessionId}/{BindingGeneration} ({ApplicationId}).")]
+    public static partial void NativeCallCompleted(
+        ILogger logger,
+        long callId,
+        string operation,
+        TimeSpan elapsed,
+        long sessionId,
+        long bindingGeneration,
+        string applicationId);
+
+    [LoggerMessage(EventId = 25, Level = LogLevel.Debug, Message = "GSMTC session reconciliation completed: {SessionCount} session(s), current {CurrentSessionId}, added {AddedCount}, retained {RetainedCount}, rebound {ReboundCount}, removed {RemovedCount}.")]
+    public static partial void SessionReconciliationCompleted(
+        ILogger logger,
+        int sessionCount,
+        long? currentSessionId,
+        int addedCount,
+        int retainedCount,
+        int reboundCount,
+        int removedCount);
+
+    [LoggerMessage(EventId = 26, Level = LogLevel.Debug, Message = "GSMTC current-session reconciliation used {Path}; current session: {CurrentSessionId}, known sessions: {KnownSessionCount}.")]
+    public static partial void CurrentSessionReconciled(
+        ILogger logger,
+        string path,
+        long? currentSessionId,
+        int knownSessionCount);
+
+    [LoggerMessage(EventId = 27, Level = LogLevel.Trace, Message = "GSMTC manager call #{CallId} {Operation} is starting.")]
+    public static partial void ManagerCallStarting(
+        ILogger logger,
+        long callId,
+        string operation);
+
+    [LoggerMessage(EventId = 28, Level = LogLevel.Trace, Message = "GSMTC manager call #{CallId} {Operation} completed in {Elapsed}.")]
+    public static partial void ManagerCallCompleted(
+        ILogger logger,
+        long callId,
+        string operation,
+        TimeSpan elapsed);
 }

--- a/src/MediaControlsExtension.Media/Infrastructure/Gsmtc/GsmtcBackend.cs
+++ b/src/MediaControlsExtension.Media/Infrastructure/Gsmtc/GsmtcBackend.cs
@@ -5,6 +5,7 @@
 // ------------------------------------------------------------
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Threading.Channels;
@@ -25,6 +26,15 @@ internal sealed class GsmtcBackend : IMediaBackend
     private const ulong MaxArtworkBytes = 32 * 1024 * 1024;
 
     [Flags]
+    private enum ManagerChanges
+    {
+        None = 0,
+        Sessions = 1 << 0,
+        CurrentSession = 1 << 1,
+        All = Sessions | CurrentSession,
+    }
+
+    [Flags]
     private enum SessionObservationChanges
     {
         None = 0,
@@ -38,20 +48,36 @@ internal sealed class GsmtcBackend : IMediaBackend
         MediaBackendSessionSnapshot? PreviousSnapshot,
         SessionObservationChanges Changes);
 
+    private readonly record struct NativeCallTrace(
+        long CallId,
+        long StartedAt);
+
+    private readonly record struct CurrentSessionResolution(
+        bool IsConsistent,
+        string Path,
+        MediaBackendSessionId? CurrentSessionId);
+
     private readonly GsmtcControlGate _controlGate;
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly ILogger _logger;
     private readonly GsmtcObservationGate _observationGate;
-    private readonly Channel<MediaBackendSignal> _signals;
+    private readonly Channel<bool> _signals;
     private readonly Lock _stateLock = new();
     private readonly Dictionary<MediaBackendSessionId, SessionBinding> _bindings = [];
 
     private GlobalSystemMediaTransportControlsSessionManager? _manager;
     private MediaBackendSessionId? _currentSessionId;
+    private long _currentSessionSignalCount;
+    private long _mediaSignalCount;
     private long _nextArtworkVersion;
     private long _nextBackendRevision;
+    private long _nextNativeCallId;
     private long _nextSessionId;
-    private int _bindingsDirty = 1;
+    private long _playbackSignalCount;
+    private long _sessionsSignalCount;
+    private long _timelineSignalCount;
+    private int _managerChanges = (int)ManagerChanges.All;
+    private int _pendingSignals;
     private int _disposeState;
     private int _startState;
 
@@ -60,7 +86,7 @@ internal sealed class GsmtcBackend : IMediaBackend
         this._logger = logger;
         this._controlGate = new(logger);
         this._observationGate = new(logger);
-        this._signals = Channel.CreateBounded<MediaBackendSignal>(new BoundedChannelOptions(1)
+        this._signals = Channel.CreateBounded<bool>(new BoundedChannelOptions(1)
         {
             SingleReader = false,
             SingleWriter = false,
@@ -94,30 +120,45 @@ internal sealed class GsmtcBackend : IMediaBackend
             this._startState = 2;
         }
 
-        this.SignalStateChanged();
+        this.SignalStateChanged(
+            MediaBackendSignal.ObservationsChanged |
+            MediaBackendSignal.SessionsChanged |
+            MediaBackendSignal.CurrentSessionChanged);
     }
 
     public async IAsyncEnumerable<MediaBackendSignal> WatchAsync(
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        await foreach (var signal in this._signals.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        await foreach (var _ in this._signals.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
         {
-            yield return signal;
+            var signal = (MediaBackendSignal)Interlocked.Exchange(
+                ref this._pendingSignals,
+                (int)MediaBackendSignal.None);
+            if (signal != MediaBackendSignal.None)
+            {
+                yield return signal;
+            }
         }
     }
 
     public async Task<MediaBackendSnapshot> ReadSnapshotAsync(CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(Volatile.Read(ref this._disposeState) != 0, this);
-        if (Interlocked.Exchange(ref this._bindingsDirty, 0) != 0)
+        this.LogAndResetSignalCounts();
+        var managerChanges = (ManagerChanges)Interlocked.Exchange(
+            ref this._managerChanges,
+            (int)ManagerChanges.None);
+        if (managerChanges != ManagerChanges.None)
         {
             try
             {
-                await this.RefreshBindingsAsync(cancellationToken).ConfigureAwait(false);
+                await this.RefreshManagerStateAsync(
+                    managerChanges,
+                    cancellationToken).ConfigureAwait(false);
             }
             catch
             {
-                Volatile.Write(ref this._bindingsDirty, 1);
+                Interlocked.Or(ref this._managerChanges, (int)managerChanges);
                 throw;
             }
         }
@@ -160,7 +201,10 @@ internal sealed class GsmtcBackend : IMediaBackend
                 binding.RestoreObservation(plan.Changes);
                 MediaLog.StaleSession(this._logger, binding.ApplicationId, "snapshot observation");
                 snapshots.Add(binding.LastSnapshot ?? CreateFallbackSnapshot(binding));
-                this.InvalidateBindings();
+                this.InvalidateManagerState(
+                    ManagerChanges.All,
+                    MediaBackendSignal.SessionsChanged |
+                    MediaBackendSignal.CurrentSessionChanged);
             }
             catch (Exception ex)
             {
@@ -222,6 +266,8 @@ internal sealed class GsmtcBackend : IMediaBackend
 
         try
         {
+            var nativeOperationName = $"Command:{command.Operation}";
+            var call = this.BeginNativeCall(target, nativeOperationName);
             var success = await this._controlGate.RunCommandAsync(
                 async () =>
                 {
@@ -244,6 +290,7 @@ internal sealed class GsmtcBackend : IMediaBackend
                 },
                 command.Operation.ToString(),
                 cancellationToken).ConfigureAwait(false);
+            this.CompleteNativeCall(target, nativeOperationName, call);
             if (success)
             {
                 target.Invalidate(ChangesForOperation(command.Operation));
@@ -263,7 +310,10 @@ internal sealed class GsmtcBackend : IMediaBackend
         }
         catch (Exception ex) when (GsmtcErrors.IndicatesStaleSession(ex))
         {
-            this.InvalidateBindings();
+            this.InvalidateManagerState(
+                ManagerChanges.All,
+                MediaBackendSignal.SessionsChanged |
+                MediaBackendSignal.CurrentSessionChanged);
             return new(MediaBackendCommandStatus.SessionGone, ex.Message);
         }
         catch (NotSupportedException ex)
@@ -297,10 +347,13 @@ internal sealed class GsmtcBackend : IMediaBackend
 
         try
         {
-            return await this._observationGate.RunAsync(
+            var call = this.BeginNativeCall(binding, "ReadArtwork");
+            var content = await this._observationGate.RunAsync(
                 () => ReadArtworkAsync(reference),
                 $"ReadArtwork:{binding.ApplicationId}",
                 cancellationToken).ConfigureAwait(false);
+            this.CompleteNativeCall(binding, "ReadArtwork", call);
+            return content;
         }
         catch (GsmtcObservationBlockedException)
         {
@@ -418,9 +471,11 @@ internal sealed class GsmtcBackend : IMediaBackend
         {
             try
             {
+                var call = this.BeginNativeCall(binding, "GetPlaybackInfo");
                 var playbackInfo = binding.Session.GetPlaybackInfo();
                 playbackState = MapPlaybackState(playbackInfo?.PlaybackStatus);
                 capabilities = MapCapabilities(playbackInfo);
+                this.CompleteNativeCall(binding, "GetPlaybackInfo", call);
             }
             catch (Exception ex) when (CanRetainObservationPart(ex))
             {
@@ -437,6 +492,7 @@ internal sealed class GsmtcBackend : IMediaBackend
         {
             try
             {
+                var call = this.BeginNativeCall(binding, "GetTimelineProperties");
                 var timeline = binding.Session.GetTimelineProperties();
                 timelineProperties = new(
                     timeline.StartTime,
@@ -445,6 +501,7 @@ internal sealed class GsmtcBackend : IMediaBackend
                     timeline.MaxSeekTime,
                     timeline.Position,
                     timeline.LastUpdatedTime);
+                this.CompleteNativeCall(binding, "GetTimelineProperties", call);
             }
             catch (Exception ex) when (CanRetainObservationPart(ex))
             {
@@ -461,6 +518,7 @@ internal sealed class GsmtcBackend : IMediaBackend
         {
             try
             {
+                var call = this.BeginNativeCall(binding, "TryGetMediaPropertiesAsync");
                 var properties = await binding.Session.TryGetMediaPropertiesAsync();
                 var artwork = binding.UpdateArtworkReference(properties?.Thumbnail);
                 mediaProperties = properties is null
@@ -477,6 +535,7 @@ internal sealed class GsmtcBackend : IMediaBackend
                         properties.AlbumTrackCount,
                         MapContentType(properties.PlaybackType),
                         artwork);
+                this.CompleteNativeCall(binding, "TryGetMediaPropertiesAsync", call);
             }
             catch (Exception ex) when (CanRetainObservationPart(ex))
             {
@@ -496,6 +555,83 @@ internal sealed class GsmtcBackend : IMediaBackend
             timelineProperties,
             playbackState,
             capabilities);
+    }
+
+    private NativeCallTrace BeginNativeCall(
+        SessionBinding binding,
+        string operation)
+    {
+        if (!this._logger.IsEnabled(LogLevel.Trace))
+        {
+            return default;
+        }
+
+        var trace = new NativeCallTrace(
+            Interlocked.Increment(ref this._nextNativeCallId),
+            Stopwatch.GetTimestamp());
+        MediaLog.NativeCallStarting(
+            this._logger,
+            trace.CallId,
+            operation,
+            binding.Id.Value,
+            binding.Generation,
+            binding.ApplicationId);
+        return trace;
+    }
+
+    private void CompleteNativeCall(
+        SessionBinding binding,
+        string operation,
+        NativeCallTrace trace)
+    {
+        if (trace.CallId == 0 || !this._logger.IsEnabled(LogLevel.Trace))
+        {
+            return;
+        }
+
+        var elapsed = Stopwatch.GetElapsedTime(trace.StartedAt);
+        MediaLog.NativeCallCompleted(
+            this._logger,
+            trace.CallId,
+            operation,
+            elapsed,
+            binding.Id.Value,
+            binding.Generation,
+            binding.ApplicationId);
+    }
+
+    private NativeCallTrace BeginManagerCall(string operation)
+    {
+        if (!this._logger.IsEnabled(LogLevel.Trace))
+        {
+            return default;
+        }
+
+        var trace = new NativeCallTrace(
+            Interlocked.Increment(ref this._nextNativeCallId),
+            Stopwatch.GetTimestamp());
+        MediaLog.ManagerCallStarting(
+            this._logger,
+            trace.CallId,
+            operation);
+        return trace;
+    }
+
+    private void CompleteManagerCall(
+        string operation,
+        NativeCallTrace trace)
+    {
+        if (trace.CallId == 0 || !this._logger.IsEnabled(LogLevel.Trace))
+        {
+            return;
+        }
+
+        var elapsed = Stopwatch.GetElapsedTime(trace.StartedAt);
+        MediaLog.ManagerCallCompleted(
+            this._logger,
+            trace.CallId,
+            operation,
+            elapsed);
     }
 
     private static bool CanRetainObservationPart(Exception exception)
@@ -681,6 +817,83 @@ internal sealed class GsmtcBackend : IMediaBackend
         return await session.TryChangeAutoRepeatModeAsync(nextMode);
     }
 
+    private async Task RefreshManagerStateAsync(
+        ManagerChanges changes,
+        CancellationToken cancellationToken)
+    {
+        if ((changes & ManagerChanges.Sessions) != 0)
+        {
+            await this.RefreshBindingsAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        if ((changes & ManagerChanges.CurrentSession) != 0 &&
+            !await this.TryRefreshCurrentSessionAsync(cancellationToken).ConfigureAwait(false))
+        {
+            await this.RefreshBindingsAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<bool> TryRefreshCurrentSessionAsync(
+        CancellationToken cancellationToken)
+    {
+        GlobalSystemMediaTransportControlsSessionManager manager;
+        SessionBinding[] bindings;
+        lock (this._stateLock)
+        {
+            manager = this._manager ?? throw new InvalidOperationException("The GSMTC backend is not started.");
+            bindings = [.. this._bindings.Values];
+        }
+
+        var resolution = await this._controlGate.RunAsync(
+            () =>
+            {
+                var call = this.BeginManagerCall("GetCurrentSession");
+                var currentSession = manager.GetCurrentSession();
+                this.CompleteManagerCall("GetCurrentSession", call);
+                if (currentSession is null)
+                {
+                    return Task.FromResult(bindings.Length == 0
+                        ? new CurrentSessionResolution(true, "fast-null-empty", null)
+                        : new CurrentSessionResolution(
+                            false,
+                            "fallback-null-with-known-sessions",
+                            null));
+                }
+
+                var referenceMatch = bindings.FirstOrDefault(
+                    binding => ReferenceEquals(binding.Session, currentSession));
+                return Task.FromResult(referenceMatch is null
+                    ? new CurrentSessionResolution(
+                        false,
+                        "fallback-unmatched-reference",
+                        null)
+                    : new CurrentSessionResolution(
+                        true,
+                        "fast-reference",
+                        referenceMatch.Id));
+            },
+            "RefreshCurrentSession",
+            cancellationToken).ConfigureAwait(false);
+
+        MediaLog.CurrentSessionReconciled(
+            this._logger,
+            resolution.Path,
+            resolution.CurrentSessionId?.Value,
+            bindings.Length);
+        if (!resolution.IsConsistent)
+        {
+            return false;
+        }
+
+        lock (this._stateLock)
+        {
+            this._currentSessionId = resolution.CurrentSessionId;
+        }
+
+        return true;
+    }
+
     private async Task RefreshBindingsAsync(CancellationToken cancellationToken)
     {
         GlobalSystemMediaTransportControlsSessionManager manager;
@@ -694,11 +907,18 @@ internal sealed class GsmtcBackend : IMediaBackend
         await this._controlGate.RunAsync(
             () =>
             {
+                var sessionsCall = this.BeginManagerCall("GetSessions");
                 var sessions = manager.GetSessions() ?? [];
+                this.CompleteManagerCall("GetSessions", sessionsCall);
+                var currentCall = this.BeginManagerCall("GetCurrentSession");
                 var currentSession = manager.GetCurrentSession();
+                this.CompleteManagerCall("GetCurrentSession", currentCall);
                 var availableExisting = existingBindings.ToList();
                 var nextBindings = new Dictionary<MediaBackendSessionId, SessionBinding>();
                 var replacedBindings = new List<SessionBinding>();
+                var addedCount = 0;
+                var retainedCount = 0;
+                var reboundCount = 0;
 
                 foreach (var session in sessions)
                 {
@@ -716,6 +936,7 @@ internal sealed class GsmtcBackend : IMediaBackend
                     SessionBinding binding;
                     if (existing is null)
                     {
+                        addedCount++;
                         binding = new(
                             this,
                             new(Interlocked.Increment(ref this._nextSessionId)),
@@ -726,11 +947,13 @@ internal sealed class GsmtcBackend : IMediaBackend
                     }
                     else if (ReferenceEquals(existing.Session, session))
                     {
+                        retainedCount++;
                         binding = existing;
                         availableExisting.Remove(existing);
                     }
                     else
                     {
+                        reboundCount++;
                         binding = new(
                             this,
                             existing.Id,
@@ -762,6 +985,15 @@ internal sealed class GsmtcBackend : IMediaBackend
                 {
                     removed.Unhook();
                 }
+
+                MediaLog.SessionReconciliationCompleted(
+                    this._logger,
+                    nextBindings.Count,
+                    currentSessionId?.Value,
+                    addedCount,
+                    retainedCount,
+                    reboundCount,
+                    availableExisting.Count);
 
                 return Task.FromResult(true);
             },
@@ -830,28 +1062,63 @@ internal sealed class GsmtcBackend : IMediaBackend
         GlobalSystemMediaTransportControlsSessionManager sender,
         SessionsChangedEventArgs args)
     {
-        this.InvalidateBindings();
+        Interlocked.Increment(ref this._sessionsSignalCount);
+        this.InvalidateManagerState(
+            ManagerChanges.All,
+            MediaBackendSignal.SessionsChanged |
+            MediaBackendSignal.CurrentSessionChanged);
     }
 
     private void ManagerOnCurrentSessionChanged(
         GlobalSystemMediaTransportControlsSessionManager sender,
         CurrentSessionChangedEventArgs args)
     {
-        this.InvalidateBindings();
+        Interlocked.Increment(ref this._currentSessionSignalCount);
+        this.InvalidateManagerState(
+            ManagerChanges.CurrentSession,
+            MediaBackendSignal.CurrentSessionChanged);
     }
 
-    private void InvalidateBindings()
+    private void InvalidateManagerState(
+        ManagerChanges changes,
+        MediaBackendSignal signal)
     {
-        Volatile.Write(ref this._bindingsDirty, 1);
-        this.SignalStateChanged();
+        Interlocked.Or(ref this._managerChanges, (int)changes);
+        this.SignalStateChanged(signal);
     }
 
-    private void SignalStateChanged()
+    private void SignalStateChanged(MediaBackendSignal signal)
     {
         if (Volatile.Read(ref this._disposeState) == 0)
         {
-            this._signals.Writer.TryWrite(MediaBackendSignal.StateChanged);
+            Interlocked.Or(ref this._pendingSignals, (int)signal);
+            this._signals.Writer.TryWrite(true);
         }
+    }
+
+    private void LogAndResetSignalCounts()
+    {
+        var playbackSignals = Interlocked.Exchange(ref this._playbackSignalCount, 0);
+        var timelineSignals = Interlocked.Exchange(ref this._timelineSignalCount, 0);
+        var mediaSignals = Interlocked.Exchange(ref this._mediaSignalCount, 0);
+        var sessionsSignals = Interlocked.Exchange(ref this._sessionsSignalCount, 0);
+        var currentSignals = Interlocked.Exchange(ref this._currentSessionSignalCount, 0);
+        if (playbackSignals == 0 &&
+            timelineSignals == 0 &&
+            mediaSignals == 0 &&
+            sessionsSignals == 0 &&
+            currentSignals == 0)
+        {
+            return;
+        }
+
+        MediaLog.NativeSignalsDrained(
+            this._logger,
+            playbackSignals,
+            timelineSignals,
+            mediaSignals,
+            sessionsSignals,
+            currentSignals);
     }
 
     private sealed class SessionBinding(
@@ -996,7 +1263,8 @@ internal sealed class GsmtcBackend : IMediaBackend
             PlaybackInfoChangedEventArgs args)
         {
             this.Invalidate(SessionObservationChanges.Playback);
-            owner.SignalStateChanged();
+            Interlocked.Increment(ref owner._playbackSignalCount);
+            owner.SignalStateChanged(MediaBackendSignal.ObservationsChanged);
         }
 
         private void SessionOnMediaPropertiesChanged(
@@ -1004,7 +1272,8 @@ internal sealed class GsmtcBackend : IMediaBackend
             MediaPropertiesChangedEventArgs args)
         {
             this.Invalidate(SessionObservationChanges.MediaProperties);
-            owner.SignalStateChanged();
+            Interlocked.Increment(ref owner._mediaSignalCount);
+            owner.SignalStateChanged(MediaBackendSignal.ObservationsChanged);
         }
 
         private void SessionOnTimelinePropertiesChanged(
@@ -1012,7 +1281,8 @@ internal sealed class GsmtcBackend : IMediaBackend
             TimelinePropertiesChangedEventArgs args)
         {
             this.Invalidate(SessionObservationChanges.Timeline);
-            owner.SignalStateChanged();
+            Interlocked.Increment(ref owner._timelineSignalCount);
+            owner.SignalStateChanged(MediaBackendSignal.ObservationsChanged);
         }
     }
 }

--- a/src/MediaControlsExtension.Media/Infrastructure/IMediaBackend.cs
+++ b/src/MediaControlsExtension.Media/Infrastructure/IMediaBackend.cs
@@ -10,9 +10,13 @@ namespace JPSoftworks.MediaControlsExtension.Media.Infrastructure;
 
 internal readonly record struct MediaBackendSessionId(long Value);
 
+[Flags]
 internal enum MediaBackendSignal
 {
-    StateChanged,
+    None = 0,
+    ObservationsChanged = 1 << 0,
+    SessionsChanged = 1 << 1,
+    CurrentSessionChanged = 1 << 2,
 }
 
 internal enum MediaBackendCommandStatus

--- a/src/MediaControlsExtension.Media/MediaRefreshRegulator.cs
+++ b/src/MediaControlsExtension.Media/MediaRefreshRegulator.cs
@@ -1,0 +1,179 @@
+// ------------------------------------------------------------
+//
+// Copyright (c) Jiří Polášek. All rights reserved.
+//
+// ------------------------------------------------------------
+
+namespace JPSoftworks.MediaControlsExtension.Media;
+
+[Flags]
+internal enum MediaRefreshReason
+{
+    None = 0,
+    ObservationsChanged = 1 << 0,
+    SessionsChanged = 1 << 1,
+    CurrentSessionChanged = 1 << 2,
+    CommandCompleted = 1 << 3,
+    CommandSettle = 1 << 4,
+    PredictionExpired = 1 << 5,
+}
+
+internal enum MediaRefreshMode
+{
+    Burst,
+    Sustained,
+}
+
+internal readonly record struct MediaRefreshAdmission(
+    TimeSpan Delay,
+    MediaRefreshMode Mode,
+    int BurstCredits,
+    int TopologyBurstCredits);
+
+internal sealed record MediaRefreshPolicy(
+    TimeSpan BurstInterval,
+    TimeSpan SustainedInterval,
+    TimeSpan QuietPeriod,
+    int BurstCapacity,
+    int TopologyBurstCapacity)
+{
+    public static MediaRefreshPolicy Default { get; } = new(
+        TimeSpan.FromMilliseconds(50),
+        TimeSpan.FromMilliseconds(250),
+        TimeSpan.FromSeconds(1),
+        3,
+        2);
+
+    public void Validate()
+    {
+        if (this.BurstInterval < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(this.BurstInterval));
+        }
+
+        if (this.SustainedInterval < this.BurstInterval)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(this.SustainedInterval),
+                "The sustained interval cannot be shorter than the burst interval.");
+        }
+
+        if (this.QuietPeriod <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(this.QuietPeriod));
+        }
+
+        if (this.BurstCapacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(this.BurstCapacity));
+        }
+
+        if (this.TopologyBurstCapacity < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(this.TopologyBurstCapacity));
+        }
+    }
+}
+
+/// <summary>
+/// Decides when a requested media snapshot may run. Request coalescing remains
+/// owned by <see cref="MediaService"/>; credits are consumed only by snapshots
+/// that actually execute.
+/// </summary>
+internal sealed class MediaRefreshRegulator
+{
+    private const MediaRefreshReason TopologyReasons =
+        MediaRefreshReason.SessionsChanged |
+        MediaRefreshReason.CurrentSessionChanged;
+
+    private readonly MediaRefreshPolicy _policy;
+    private readonly TimeProvider _timeProvider;
+    private int _burstCredits;
+    private int _topologyBurstCredits;
+    private bool _hasExecutionTimestamp;
+    private bool _hasRequestTimestamp;
+    private long _lastExecutionTimestamp;
+    private long _lastRequestTimestamp;
+
+    public MediaRefreshRegulator(
+        TimeProvider timeProvider,
+        MediaRefreshPolicy policy)
+    {
+        this._timeProvider = timeProvider;
+        this._policy = policy;
+        this._policy.Validate();
+        this.ResetBurstCredits();
+    }
+
+    public bool RegisterRequest(long timestamp)
+    {
+        var startsNewBurst = !this._hasRequestTimestamp ||
+            this._timeProvider.GetElapsedTime(this._lastRequestTimestamp, timestamp) >=
+                this._policy.QuietPeriod;
+        if (startsNewBurst)
+        {
+            this.ResetBurstCredits();
+        }
+
+        this._lastRequestTimestamp = timestamp;
+        this._hasRequestTimestamp = true;
+        return startsNewBurst;
+    }
+
+    public MediaRefreshAdmission GetAdmission(
+        long timestamp,
+        MediaRefreshReason reasons)
+    {
+        var topologyBurstAvailable =
+            (reasons & TopologyReasons) != 0 &&
+            this._topologyBurstCredits > 0;
+        var usesBurst = this._burstCredits > 0 || topologyBurstAvailable;
+        var interval = usesBurst
+            ? this._policy.BurstInterval
+            : this._policy.SustainedInterval;
+        var delay = TimeSpan.Zero;
+        if (this._hasExecutionTimestamp)
+        {
+            var elapsed = this._timeProvider.GetElapsedTime(
+                this._lastExecutionTimestamp,
+                timestamp);
+            if (elapsed < interval)
+            {
+                delay = interval - elapsed;
+            }
+        }
+
+        return new(
+            delay,
+            usesBurst ? MediaRefreshMode.Burst : MediaRefreshMode.Sustained,
+            this._burstCredits,
+            this._topologyBurstCredits);
+    }
+
+    public void RegisterExecution(
+        long timestamp,
+        MediaRefreshReason reasons)
+    {
+        var usedGeneralBurstCredit = this._burstCredits > 0;
+        if (this._burstCredits > 0)
+        {
+            this._burstCredits--;
+        }
+
+        if (!usedGeneralBurstCredit &&
+            (reasons & TopologyReasons) != 0 &&
+            this._topologyBurstCredits > 0)
+        {
+            this._topologyBurstCredits--;
+        }
+
+        this._lastExecutionTimestamp = timestamp;
+        this._hasExecutionTimestamp = true;
+    }
+
+    private void ResetBurstCredits()
+    {
+        this._burstCredits = this._policy.BurstCapacity;
+        this._topologyBurstCredits = this._policy.TopologyBurstCapacity;
+    }
+}

--- a/src/MediaControlsExtension.Media/MediaService.cs
+++ b/src/MediaControlsExtension.Media/MediaService.cs
@@ -5,6 +5,7 @@
 // ------------------------------------------------------------
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Threading.Channels;
 using JPSoftworks.MediaControlsExtension.Media.Diagnostics;
 using JPSoftworks.MediaControlsExtension.Media.Infrastructure;
@@ -29,6 +30,8 @@ public sealed class MediaService : IMediaService
     private readonly Dictionary<MediaBackendSessionId, MediaBackendObservationChanges>
         _commandSettleRefreshRequests = [];
     private readonly Timer _commandSettleRefreshTimer;
+    private readonly Lock _refreshAdmissionLock = new();
+    private readonly MediaRefreshRegulator _refreshRegulator;
     private readonly Channel<bool> _refreshRequests;
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly Lock _lifecycleLock = new();
@@ -46,7 +49,12 @@ public sealed class MediaService : IMediaService
     private Task? _backendSignalPumpTask;
     private Task? _disposeTask;
     private Task? _refreshPumpTask;
+    private CancellationTokenSource? _activeRefreshDelayCts;
+    private MediaRefreshMode? _activeRefreshDelayMode;
     private long _nextOperationId;
+    private long _nextRefreshId;
+    private MediaRefreshReason _pendingRefreshReasons;
+    private int _pendingRefreshRequestCount;
     private int _startState;
     private int _disposeState;
 
@@ -58,6 +66,7 @@ public sealed class MediaService : IMediaService
         this._commandQueue = CreateCommandQueue();
         this._refreshRequests = CreateRefreshQueue();
         this._timeProvider = TimeProvider.System;
+        this._refreshRegulator = new(this._timeProvider, MediaRefreshPolicy.Default);
         this._playbackPredictionLifetime = PlaybackPredictionLifetime;
         this._commandSettleRefreshTimer = this.CreateCommandSettleRefreshTimer();
         this._notificationHub = new(this.RaiseChanged, this._logger);
@@ -68,13 +77,17 @@ public sealed class MediaService : IMediaService
         IMediaBackend backend,
         ILogger<MediaService>? logger = null,
         TimeProvider? timeProvider = null,
-        TimeSpan? playbackPredictionLifetime = null)
+        TimeSpan? playbackPredictionLifetime = null,
+        MediaRefreshPolicy? refreshPolicy = null)
     {
         this._backend = backend ?? throw new ArgumentNullException(nameof(backend));
         this._logger = logger ?? NullLogger<MediaService>.Instance;
         this._commandQueue = CreateCommandQueue();
         this._refreshRequests = CreateRefreshQueue();
         this._timeProvider = timeProvider ?? TimeProvider.System;
+        this._refreshRegulator = new(
+            this._timeProvider,
+            refreshPolicy ?? MediaRefreshPolicy.Default);
         this._playbackPredictionLifetime =
             playbackPredictionLifetime ?? PlaybackPredictionLifetime;
         if (this._playbackPredictionLifetime <= TimeSpan.Zero)
@@ -151,7 +164,6 @@ public sealed class MediaService : IMediaService
                 this._backendSignalPumpTask = Task.Run(
                     () => this.ProcessBackendSignalsAsync(disposeToken),
                     CancellationToken.None);
-                this.RequestRefresh();
 
                 this._startState = 2;
                 MediaLog.ServiceReady(this._logger, this.Sessions.Length);
@@ -436,16 +448,16 @@ public sealed class MediaService : IMediaService
             this.ScheduleCommandSettleRefresh(command);
         }
 
-        this.RequestRefresh();
+        this.RequestRefresh(MediaRefreshReason.CommandCompleted);
     }
 
     private async Task ProcessBackendSignalsAsync(CancellationToken cancellationToken)
     {
         try
         {
-            await foreach (var _ in this._backend.WatchAsync(cancellationToken).ConfigureAwait(false))
+            await foreach (var signal in this._backend.WatchAsync(cancellationToken).ConfigureAwait(false))
             {
-                this.RequestRefresh();
+                this.RequestRefresh(MapRefreshReason(signal));
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -465,9 +477,90 @@ public sealed class MediaService : IMediaService
     {
         try
         {
-            await foreach (var _ in this._refreshRequests.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            while (await this._refreshRequests.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                await this.RefreshSnapshotAsync(cancellationToken).ConfigureAwait(false);
+                while (this._refreshRequests.Reader.TryRead(out _))
+                {
+                }
+
+                while (true)
+                {
+                    MediaRefreshAdmission admission;
+                    lock (this._refreshAdmissionLock)
+                    {
+                        if (this._pendingRefreshReasons == MediaRefreshReason.None)
+                        {
+                            break;
+                        }
+
+                        admission = this._refreshRegulator.GetAdmission(
+                            this._timeProvider.GetTimestamp(),
+                            this._pendingRefreshReasons);
+                    }
+
+                    if (admission.Delay > TimeSpan.Zero &&
+                        await this.WaitForRefreshAdmissionAsync(
+                            admission.Delay,
+                            admission.Mode,
+                            cancellationToken).ConfigureAwait(false))
+                    {
+                        continue;
+                    }
+
+                    MediaRefreshReason reasons;
+                    int requestCount;
+                    lock (this._refreshAdmissionLock)
+                    {
+                        reasons = this._pendingRefreshReasons;
+                        requestCount = this._pendingRefreshRequestCount;
+                        this._pendingRefreshReasons = MediaRefreshReason.None;
+                        this._pendingRefreshRequestCount = 0;
+                        admission = this._refreshRegulator.GetAdmission(
+                            this._timeProvider.GetTimestamp(),
+                            reasons);
+                    }
+
+                    if (reasons == MediaRefreshReason.None)
+                    {
+                        break;
+                    }
+
+                    var refreshId = Interlocked.Increment(ref this._nextRefreshId);
+                    MediaLog.RefreshStarting(
+                        this._logger,
+                        refreshId,
+                        admission.Mode,
+                        requestCount,
+                        reasons,
+                        admission.BurstCredits,
+                        admission.TopologyBurstCredits);
+                    var startedAt = Stopwatch.GetTimestamp();
+                    await this.RefreshSnapshotAsync(cancellationToken).ConfigureAwait(false);
+                    var completedAt = this._timeProvider.GetTimestamp();
+                    lock (this._refreshAdmissionLock)
+                    {
+                        this._refreshRegulator.RegisterExecution(completedAt, reasons);
+                    }
+
+                    if (this._logger.IsEnabled(LogLevel.Debug))
+                    {
+                        var refreshElapsed = Stopwatch.GetElapsedTime(startedAt);
+                        var sessionCount = this.Sessions.Length;
+                        var currentSessionId = this.CurrentSession?.Id.Value;
+                        var status = this.Status;
+                        MediaLog.RefreshCompleted(
+                            this._logger,
+                            refreshId,
+                            refreshElapsed,
+                            sessionCount,
+                            currentSessionId,
+                            status);
+                    }
+
+                    while (this._refreshRequests.Reader.TryRead(out _))
+                    {
+                    }
+                }
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -497,8 +590,106 @@ public sealed class MediaService : IMediaService
         }
     }
 
-    private void RequestRefresh()
+    private static MediaRefreshReason MapRefreshReason(MediaBackendSignal signal)
     {
+        var reason = MediaRefreshReason.None;
+        if ((signal & MediaBackendSignal.ObservationsChanged) != 0)
+        {
+            reason |= MediaRefreshReason.ObservationsChanged;
+        }
+
+        if ((signal & MediaBackendSignal.SessionsChanged) != 0)
+        {
+            reason |= MediaRefreshReason.SessionsChanged;
+        }
+
+        if ((signal & MediaBackendSignal.CurrentSessionChanged) != 0)
+        {
+            reason |= MediaRefreshReason.CurrentSessionChanged;
+        }
+
+        return reason;
+    }
+
+    private async Task<bool> WaitForRefreshAdmissionAsync(
+        TimeSpan delay,
+        MediaRefreshMode mode,
+        CancellationToken cancellationToken)
+    {
+        using var delayCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        lock (this._refreshAdmissionLock)
+        {
+            var updatedAdmission = this._refreshRegulator.GetAdmission(
+                this._timeProvider.GetTimestamp(),
+                this._pendingRefreshReasons);
+            if (updatedAdmission.Delay < delay)
+            {
+                delay = updatedAdmission.Delay;
+                mode = updatedAdmission.Mode;
+            }
+
+            this._activeRefreshDelayCts = delayCts;
+            this._activeRefreshDelayMode = mode;
+        }
+
+        try
+        {
+            await Task.Delay(delay, delayCts.Token).ConfigureAwait(false);
+            return false;
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return true;
+        }
+        finally
+        {
+            lock (this._refreshAdmissionLock)
+            {
+                if (ReferenceEquals(this._activeRefreshDelayCts, delayCts))
+                {
+                    this._activeRefreshDelayCts = null;
+                    this._activeRefreshDelayMode = null;
+                }
+            }
+        }
+    }
+
+    private void RequestRefresh(MediaRefreshReason reason)
+    {
+        if (reason == MediaRefreshReason.None)
+        {
+            return;
+        }
+
+        CancellationTokenSource? delayToCancel = null;
+        lock (this._refreshAdmissionLock)
+        {
+            this._pendingRefreshReasons |= reason;
+            if (this._pendingRefreshRequestCount < int.MaxValue)
+            {
+                this._pendingRefreshRequestCount++;
+            }
+
+            var timestamp = this._timeProvider.GetTimestamp();
+            this._refreshRegulator.RegisterRequest(timestamp);
+            var updatedAdmission = this._refreshRegulator.GetAdmission(
+                timestamp,
+                this._pendingRefreshReasons);
+            if (this._activeRefreshDelayMode == MediaRefreshMode.Sustained &&
+                updatedAdmission.Mode == MediaRefreshMode.Burst)
+            {
+                delayToCancel = this._activeRefreshDelayCts;
+            }
+        }
+
+        try
+        {
+            delayToCancel?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
         this._refreshRequests.Writer.TryWrite(true);
     }
 
@@ -612,7 +803,7 @@ public sealed class MediaService : IMediaService
         }
 
         this._backend.InvalidateObservations(requests);
-        this.RequestRefresh();
+        this.RequestRefresh(MediaRefreshReason.CommandSettle);
     }
 
     private async Task ExpirePredictionAsync(
@@ -633,7 +824,7 @@ public sealed class MediaService : IMediaService
         if (this._stateStore.TryExpirePrediction(sessionId, operationId, out var snapshot))
         {
             this.PublishState(snapshot);
-            this.RequestRefresh();
+            this.RequestRefresh(MediaRefreshReason.PredictionExpired);
         }
     }
 

--- a/src/MediaControlsExtension/Commands/ToggleDetailedLoggingCommand.cs
+++ b/src/MediaControlsExtension/Commands/ToggleDetailedLoggingCommand.cs
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------
+//
+// Copyright (c) Jiří Polášek. All rights reserved.
+//
+// ------------------------------------------------------------
+
+namespace JPSoftworks.MediaControlsExtension.Commands;
+
+internal sealed partial class ToggleDetailedLoggingCommand : InvokableCommand
+{
+    private Action<bool>? _stateChanged;
+
+    public ToggleDetailedLoggingCommand()
+    {
+        this.UpdatePresentation(DetailedLoggingMode.IsEnabled);
+    }
+
+    public override ICommandResult Invoke()
+    {
+        var enabled = DetailedLoggingMode.Toggle();
+        this.UpdatePresentation(enabled);
+        this._stateChanged?.Invoke(enabled);
+        return CommandResult.KeepOpen();
+    }
+
+    internal void SetStateChangedHandler(Action<bool> stateChanged)
+    {
+        ArgumentNullException.ThrowIfNull(stateChanged);
+        this._stateChanged = stateChanged;
+    }
+
+    private void UpdatePresentation(bool enabled)
+    {
+        this.Name = enabled
+            ? Strings.ReportProblem_DetailedLogging_Disable_Title!
+            : Strings.ReportProblem_DetailedLogging_Enable_Title!;
+        this.Icon = enabled
+            ? Icons.DetailedLoggingDisabled
+            : Icons.DetailedLoggingEnabled;
+    }
+}

--- a/src/MediaControlsExtension/Icons.cs
+++ b/src/MediaControlsExtension/Icons.cs
@@ -55,6 +55,8 @@ internal static class Icons
     public static IconInfo PreviousApp { get; } = new IconInfo("\uEA52");
 
     public static IconInfo ReportProblem { get; } = new(SegoeFluentIconGlyphs.Bug);
+    public static IconInfo DetailedLoggingEnabled { get; } = new(SegoeFluentIconGlyphs.CheckboxComposite);
+    public static IconInfo DetailedLoggingDisabled { get; } = new(SegoeFluentIconGlyphs.Checkbox);
     public static IconInfo Save { get; } = new(SegoeFluentIconGlyphs.Save);
     public static IconInfo OpenInNewWindow { get; } = new(SegoeFluentIconGlyphs.OpenInNewWindow);
 }
@@ -73,6 +75,8 @@ internal static class SegoeFluentIconGlyphs
     public const string VolumeDown = VolumeLow;
 
     public const string Bug = "\uEBE8";
+    public const string Checkbox = "\uE739";
+    public const string CheckboxComposite = "\uE73A";
     public const string Save = "\uE74E";
     public const string OpenInNewWindow = "\uE8A7";
 }

--- a/src/MediaControlsExtension/Pages/DetailedLoggingListItem.cs
+++ b/src/MediaControlsExtension/Pages/DetailedLoggingListItem.cs
@@ -1,0 +1,64 @@
+// ------------------------------------------------------------
+//
+// Copyright (c) Jiří Polášek. All rights reserved.
+//
+// ------------------------------------------------------------
+
+namespace JPSoftworks.MediaControlsExtension.Pages;
+
+internal sealed partial class DetailedLoggingListItem : ListItemBase
+{
+    private readonly ITag[] _enabledTags;
+    private readonly ITag[] _disabledTags;
+
+    public DetailedLoggingListItem()
+        : this(new ToggleDetailedLoggingCommand())
+    {
+    }
+
+    private DetailedLoggingListItem(
+        ToggleDetailedLoggingCommand command)
+        : base(command)
+    {
+        this._enabledTags =
+        [
+            CreateStateTag(
+                Strings.ReportProblem_DetailedLogging_Enabled_Label!,
+                Icons.DetailedLoggingEnabled,
+                ColorHelpers.FromRgb(16, 124, 16)),
+        ];
+        this._disabledTags =
+        [
+            CreateStateTag(
+                Strings.ReportProblem_DetailedLogging_Disabled_Label!,
+                Icons.DetailedLoggingDisabled,
+                ColorHelpers.FromRgb(96, 94, 92)),
+        ];
+
+        command.SetStateChangedHandler(this.UpdatePresentation);
+        this.UpdatePresentation(DetailedLoggingMode.IsEnabled);
+    }
+
+    private void UpdatePresentation(bool enabled)
+    {
+        this.Title = Strings.ReportProblem_DetailedLogging_Title!;
+        this.Subtitle = enabled
+            ? Strings.ReportProblem_DetailedLogging_Enabled_Subtitle!
+            : Strings.ReportProblem_DetailedLogging_Disabled_Subtitle!;
+        this.Icon = enabled
+            ? Icons.DetailedLoggingEnabled
+            : Icons.DetailedLoggingDisabled;
+        this.Tags = enabled ? this._enabledTags : this._disabledTags;
+    }
+
+    private static Tag CreateStateTag(string text, IconInfo icon, OptionalColor background)
+    {
+        return new Tag(text)
+        {
+            Icon = icon,
+            Foreground = ColorHelpers.FromRgb(255, 255, 255),
+            Background = background,
+            ToolTip = text,
+        };
+    }
+}

--- a/src/MediaControlsExtension/Pages/ReportProblemPage.cs
+++ b/src/MediaControlsExtension/Pages/ReportProblemPage.cs
@@ -43,6 +43,11 @@ internal sealed partial class ReportProblemPage : ListPage
                 Subtitle = Strings.ReportProblem_OpenGitHub_Subtitle!,
                 Details = instructions,
             },
+            new Separator(),
+            new DetailedLoggingListItem()
+            {
+                Details = instructions,
+            },
         ];
     }
 

--- a/src/MediaControlsExtension/Program.cs
+++ b/src/MediaControlsExtension/Program.cs
@@ -21,11 +21,14 @@ internal static class Program
                 PublisherMoniker = ExtensionHostIdentity.PublisherMoniker,
                 ProductMoniker = ExtensionHostIdentity.ProductMoniker,
             });
+        DetailedLoggingMode.InitializeForProcess(host.IsDebug);
 
         using var loggerFactory = LoggerFactory.Create(builder =>
             builder
                 .AddDailyFile(host)
-                .AddCommandPalette(host));
+                .AddFilter<DailyFileLoggerProvider>(static (_, level) => DetailedLoggingMode.ShouldWriteToFile(level))
+                .AddCommandPalette(host)
+                .AddFilter<CommandPaletteLoggerProvider>(static (_, level) => level is >= LogLevel.Critical and < LogLevel.None));
 
         await ExtensionHostRunner.CreateBuilder(host)
             .AddHostedExtensionFactory(context => new MediaControlsExtension(context.ExtensionDisposedEvent, loggerFactory))

--- a/src/MediaControlsExtension/Resources/Strings.Designer.cs
+++ b/src/MediaControlsExtension/Resources/Strings.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace JPSoftworks.MediaControlsExtension.Resources {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Strings() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Mute.
         /// </summary>
@@ -68,7 +68,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_Mute", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Mute system volume.
         /// </summary>
@@ -77,7 +77,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_Mute_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Next Application.
         /// </summary>
@@ -86,7 +86,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_NextApp", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Next Track.
         /// </summary>
@@ -95,7 +95,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_NextTrack", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Skip to the next track in the active media session.
         /// </summary>
@@ -104,7 +104,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_NextTrack_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Pause.
         /// </summary>
@@ -113,7 +113,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_Pause", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Play.
         /// </summary>
@@ -122,7 +122,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_Play", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Play / Pause.
         /// </summary>
@@ -131,7 +131,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_PlayPause", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Previous Application.
         /// </summary>
@@ -140,7 +140,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_PreviousApp", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Previous Track.
         /// </summary>
@@ -149,7 +149,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_PreviousTrack", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Returns to the previous track in the active media session.
         /// </summary>
@@ -158,7 +158,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_PreviousTrack_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Set volume to {0}%.
         /// </summary>
@@ -167,7 +167,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_SetVolume", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Stop.
         /// </summary>
@@ -176,7 +176,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_Stop", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Switch to Application.
         /// </summary>
@@ -185,7 +185,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_SwitchToApplication", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Toggle volume mute.
         /// </summary>
@@ -194,7 +194,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_ToggleMute", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Toggle Repeat.
         /// </summary>
@@ -203,7 +203,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_ToggleRepeat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Toggle Shuffle.
         /// </summary>
@@ -212,7 +212,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_ToggleShuffle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unmute.
         /// </summary>
@@ -221,7 +221,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_Unmute", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unmute system volume.
         /// </summary>
@@ -230,7 +230,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_Unmute_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to View full metadata.
         /// </summary>
@@ -239,7 +239,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_ViewMetadata", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Volume down.
         /// </summary>
@@ -248,7 +248,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_VolumeDown", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Volume up.
         /// </summary>
@@ -257,7 +257,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Command_VolumeUp", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Album.
         /// </summary>
@@ -266,7 +266,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_Album", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Album artist.
         /// </summary>
@@ -275,7 +275,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_AlbumArtist", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Application ID.
         /// </summary>
@@ -284,7 +284,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_ApplicationId", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Artist.
         /// </summary>
@@ -293,7 +293,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_Artist", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Commands.
         /// </summary>
@@ -302,7 +302,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_Commands", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Genres.
         /// </summary>
@@ -311,7 +311,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_Genres", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Length.
         /// </summary>
@@ -320,7 +320,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_Length", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Media type.
         /// </summary>
@@ -329,7 +329,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_MediaType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Image.
         /// </summary>
@@ -338,7 +338,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_MediaType_Image", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Music.
         /// </summary>
@@ -347,7 +347,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_MediaType_Music", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unknown.
         /// </summary>
@@ -356,7 +356,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_MediaType_Unknown", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Video.
         /// </summary>
@@ -365,7 +365,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_MediaType_Video", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Not available.
         /// </summary>
@@ -374,7 +374,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_NotAvailable", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Playback status.
         /// </summary>
@@ -383,7 +383,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_PlaybackStatus", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Player.
         /// </summary>
@@ -392,7 +392,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_Player", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Subtitle.
         /// </summary>
@@ -401,7 +401,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Title.
         /// </summary>
@@ -410,7 +410,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Track.
         /// </summary>
@@ -419,7 +419,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_TrackNumber", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} of {1}.
         /// </summary>
@@ -428,7 +428,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Details_TrackNumberWithCount", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No media sources are currently available. Please ensure that you have media applications running that support media controls..
         /// </summary>
@@ -437,7 +437,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("EmptyContent_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No media sources available.
         /// </summary>
@@ -446,7 +446,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("EmptyContent_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Manage playback and switch between media apps with ease.
         /// </summary>
@@ -455,7 +455,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("MediaControls_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Album artwork.
         /// </summary>
@@ -464,7 +464,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Metadata_ArtworkAltText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No media metadata is available..
         /// </summary>
@@ -473,7 +473,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Metadata_NoMedia", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Media metadata.
         /// </summary>
@@ -482,7 +482,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Metadata_PageTitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Metadata.
         /// </summary>
@@ -491,7 +491,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Metadata_Section", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Technical information.
         /// </summary>
@@ -500,7 +500,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Metadata_TechnicalSection", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Media Controls.
         /// </summary>
@@ -509,7 +509,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Name", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Nothing is playing right now.
         /// </summary>
@@ -518,7 +518,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("NowPlaying_NothingPlaying", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Now playing {0}.
         /// </summary>
@@ -527,7 +527,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("NowPlaying_NowPlaying", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Pause {0}.
         /// </summary>
@@ -536,7 +536,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("NowPlaying_Pause", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Play {0}.
         /// </summary>
@@ -545,7 +545,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("NowPlaying_Play", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Stop {0}.
         /// </summary>
@@ -554,7 +554,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("NowPlaying_Stop", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Now playing.
         /// </summary>
@@ -563,7 +563,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("NowPlaying_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Open.
         /// </summary>
@@ -572,7 +572,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Open", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Media sessions.
         /// </summary>
@@ -581,7 +581,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Page_Section_MediaSessions", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Playback.
         /// </summary>
@@ -590,7 +590,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Page_Section_Playback", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to System volume.
         /// </summary>
@@ -599,7 +599,70 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Page_Section_SystemVolume", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Disable.
+        /// </summary>
+        internal static string ReportProblem_DetailedLogging_Disable_Title {
+            get {
+                return ResourceManager.GetString("ReportProblem_DetailedLogging_Disable_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Disabled.
+        /// </summary>
+        internal static string ReportProblem_DetailedLogging_Disabled_Label {
+            get {
+                return ResourceManager.GetString("ReportProblem_DetailedLogging_Disabled_Label", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enable high-volume Debug and Trace entries in daily log files for this run only; the option resets on restart..
+        /// </summary>
+        internal static string ReportProblem_DetailedLogging_Disabled_Subtitle {
+            get {
+                return ResourceManager.GetString("ReportProblem_DetailedLogging_Disabled_Subtitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enable.
+        /// </summary>
+        internal static string ReportProblem_DetailedLogging_Enable_Title {
+            get {
+                return ResourceManager.GetString("ReportProblem_DetailedLogging_Enable_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enabled.
+        /// </summary>
+        internal static string ReportProblem_DetailedLogging_Enabled_Label {
+            get {
+                return ResourceManager.GetString("ReportProblem_DetailedLogging_Enabled_Label", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Daily log files include high-volume Debug and Trace entries until the option is disabled or the extension restarts..
+        /// </summary>
+        internal static string ReportProblem_DetailedLogging_Enabled_Subtitle {
+            get {
+                return ResourceManager.GetString("ReportProblem_DetailedLogging_Enabled_Subtitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Detailed logging.
+        /// </summary>
+        internal static string ReportProblem_DetailedLogging_Title {
+            get {
+                return ResourceManager.GetString("ReportProblem_DetailedLogging_Title", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to To report a problem:
         ///
@@ -696,7 +759,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("SearchPlaceholder", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Created by [Jiří Polášek](https://jiripolasek.com)
         ///_Licensed under the Apache 2.0 license_
@@ -709,7 +772,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_Acknowledgements", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Choose icons for the Command Palette home page and Media Controls list page..
         /// </summary>
@@ -718,7 +781,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_CommandPaletteIconTheme_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Icon theme.
         /// </summary>
@@ -727,7 +790,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_CommandPaletteIconTheme_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Default (Switch to player).
         /// </summary>
@@ -736,7 +799,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_DockCurrentMediaAction_Option_Default", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Open Media Controls.
         /// </summary>
@@ -745,7 +808,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_DockCurrentMediaAction_Option_OpenMediaControls", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Open media metadata.
         /// </summary>
@@ -754,7 +817,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_DockCurrentMediaAction_Option_OpenMediaMetadata", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Switch to player.
         /// </summary>
@@ -763,7 +826,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_DockCurrentMediaAction_Option_SwitchToPlayer", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Choose what happens when you select the current media item in the Dock..
         /// </summary>
@@ -772,7 +835,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_DockCurrentMediaAction_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Current media item action.
         /// </summary>
@@ -781,7 +844,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_DockCurrentMediaAction_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Choose icons for the Command Palette Dock..
         /// </summary>
@@ -790,7 +853,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_DockIconTheme_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Icon theme.
         /// </summary>
@@ -799,7 +862,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_DockIconTheme_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show this extension&apos;s system volume commands. Turn this off if another extension already provides them..
         /// </summary>
@@ -808,7 +871,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_EnableVolumeControls_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Enable volume controls.
         /// </summary>
@@ -817,7 +880,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_EnableVolumeControls_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Disabled.
         /// </summary>
@@ -826,7 +889,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_GlobalCommands_Option_Disabled", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Enabled.
         /// </summary>
@@ -835,7 +898,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_GlobalCommands_Option_Enabled", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show additional Media Controls commands in global search results..
         /// </summary>
@@ -844,7 +907,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_GlobalCommands_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Additional global commands.
         /// </summary>
@@ -853,7 +916,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_GlobalCommands_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Appearance and behavior.
         /// </summary>
@@ -862,7 +925,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_Group_AppearanceAndBehavior", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Commands.
         /// </summary>
@@ -871,7 +934,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_Group_Commands", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Dock.
         /// </summary>
@@ -880,7 +943,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_Group_Dock", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Help and acknowledgements.
         /// </summary>
@@ -889,7 +952,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_Group_HelpAndAcknowledgements", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Command Palette page.
         /// </summary>
@@ -898,7 +961,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_Group_PalettePage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [Get help, report a problem, or view the source code](https://github.com/jiripolasek/MediaControlsExtension).
         /// </summary>
@@ -907,7 +970,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_Help", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Hide after changing tracks.
         /// </summary>
@@ -916,7 +979,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_HideAfterChangingTracks", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Hide after Play/Pause.
         /// </summary>
@@ -925,7 +988,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_HideAfterPlayPause", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Hide after toggle play/pause on media session.
         /// </summary>
@@ -934,7 +997,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_HideAfterTogglePlayPause", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Default ({0}).
         /// </summary>
@@ -943,7 +1006,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_IconTheme_Default", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Run multiple media commands in sequence without reopening Command Palette. Hold Shift while running a command to temporarily reverse this behavior..
         /// </summary>
@@ -952,7 +1015,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_KeepOpen_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Keep Command Palette open after a command.
         /// </summary>
@@ -961,7 +1024,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_KeepOpen_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to When playing a session, automatically pause all other sessions..
         /// </summary>
@@ -970,7 +1033,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_PauseOthersOnPlay_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Pause other sessions when playback starts.
         /// </summary>
@@ -979,7 +1042,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_PauseOthersOnPlay_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Add a “Now Playing” item for quick access to the current media session..
         /// </summary>
@@ -988,7 +1051,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowCurrentMediaAtTopLevel_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show the current media session on the home page.
         /// </summary>
@@ -997,7 +1060,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowCurrentMediaAtTopLevel_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Open the details pane automatically on the Media Controls page..
         /// </summary>
@@ -1006,7 +1069,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowDetails_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show media details by default.
         /// </summary>
@@ -1015,7 +1078,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowDetails_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Display “Next Track” and “Previous Track” on the Media Controls page..
         /// </summary>
@@ -1024,7 +1087,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowSkipCommands_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show track navigation commands.
         /// </summary>
@@ -1033,7 +1096,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowSkipCommands_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Display “Next Track” and “Previous Track” in the Dock..
         /// </summary>
@@ -1042,7 +1105,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowSkipCommandsInDock_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show track navigation commands.
         /// </summary>
@@ -1051,7 +1114,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowSkipCommandsInDock_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Use media thumbnails (album art) instead of app icons in the session list..
         /// </summary>
@@ -1060,7 +1123,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowThumbnails_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show thumbnails.
         /// </summary>
@@ -1069,7 +1132,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowThumbnails_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show a notification after each media action..
         /// </summary>
@@ -1078,7 +1141,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowToastMessages_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show action confirmations.
         /// </summary>
@@ -1087,7 +1150,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowToastMessages_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show Volume Down and Volume Up in the system volume Dock band..
         /// </summary>
@@ -1096,7 +1159,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowVolumeAdjustmentCommandsInDock_Subtitle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Show volume adjustment buttons.
         /// </summary>
@@ -1105,7 +1168,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Settings_ShowVolumeAdjustmentCommandsInDock_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Playing.
         /// </summary>
@@ -1114,7 +1177,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Tags_Playing", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Can&apos;t change the volume.
         /// </summary>
@@ -1123,7 +1186,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_CantChangeVolume", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not change repeat mode.
         /// </summary>
@@ -1132,7 +1195,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_CouldNotChangeRepeat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not pause playback.
         /// </summary>
@@ -1141,7 +1204,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_CouldNotPause", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not play track.
         /// </summary>
@@ -1150,7 +1213,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_CouldNotPlay", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not skip to next track.
         /// </summary>
@@ -1159,7 +1222,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_CouldNotSkipNext", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not go to previous track.
         /// </summary>
@@ -1168,7 +1231,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_CouldNotSkipPrevious", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not switch to {0}: {1}.
         /// </summary>
@@ -1177,7 +1240,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_CouldNotSwitchTo", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not toggle shuffle.
         /// </summary>
@@ -1186,7 +1249,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_CouldNotToggleShuffle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Media controls stopped responding. Restart the extension to retry..
         /// </summary>
@@ -1195,7 +1258,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_MediaControlsUnavailable", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Muted.
         /// </summary>
@@ -1204,7 +1267,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_Muted", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No current media session found.
         /// </summary>
@@ -1213,7 +1276,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_NoCurrentSession", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No next session found.
         /// </summary>
@@ -1222,7 +1285,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_NoNextSession", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No other sessions to switch to.
         /// </summary>
@@ -1231,7 +1294,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_NoOtherSessions", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No media session manager found.
         /// </summary>
@@ -1240,7 +1303,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_NoSessionManager", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Not the current session.
         /// </summary>
@@ -1249,7 +1312,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_NotCurrentSession", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Nothing happened.
         /// </summary>
@@ -1258,7 +1321,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_NothingHappened", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Nothing is playing.
         /// </summary>
@@ -1267,7 +1330,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_NothingPlaying", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Paused.
         /// </summary>
@@ -1276,7 +1339,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_Paused", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Playing.
         /// </summary>
@@ -1285,7 +1348,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_Playing", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Playing {0}.
         /// </summary>
@@ -1294,7 +1357,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_PlayingName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Repeat mode changed to {0}.
         /// </summary>
@@ -1303,7 +1366,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_RepeatChanged", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Repeat control is not available for this session.
         /// </summary>
@@ -1312,7 +1375,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_RepeatNotAvailable", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Shuffle disabled.
         /// </summary>
@@ -1321,7 +1384,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_ShuffleDisabled", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Shuffle enabled.
         /// </summary>
@@ -1330,7 +1393,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_ShuffleEnabled", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Shuffle control is not available for this session.
         /// </summary>
@@ -1339,7 +1402,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_ShuffleNotAvailable", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Skipped to next track.
         /// </summary>
@@ -1348,7 +1411,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_SkippedNext", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Returned to previous track.
         /// </summary>
@@ -1357,7 +1420,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_SkippedPrevious", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Switched to {0} and {1}.
         /// </summary>
@@ -1366,7 +1429,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_SwitchedTo", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unmuted.
         /// </summary>
@@ -1375,7 +1438,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_Unmuted", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Volume.
         /// </summary>
@@ -1384,7 +1447,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Toast_Volume", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Toggle Play / Pause.
         /// </summary>
@@ -1393,7 +1456,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("TogglePlayPause", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Play or pause current media.
         /// </summary>
@@ -1402,7 +1465,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("TogglePlayPause_Comments", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0}%.
         /// </summary>
@@ -1411,7 +1474,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Volume_Level", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Volume - {0} %.
         /// </summary>
@@ -1420,7 +1483,7 @@ namespace JPSoftworks.MediaControlsExtension.Resources {
                 return ResourceManager.GetString("Volume_Status", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Volume - muted.
         /// </summary>

--- a/src/MediaControlsExtension/Resources/Strings.cs-CZ.resx
+++ b/src/MediaControlsExtension/Resources/Strings.cs-CZ.resx
@@ -561,6 +561,27 @@ Zvláštní poděkování patří [Mikeovi Griesemu](https://github.com/zadjii-m
 
 Diagnostické protokoly mohou obsahovat názvy médií, názvy přehrávačů a technické podrobnosti o chybách. Před sdílením archiv zkontrolujte.</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>Povolit</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>Zakázat</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>Podrobné protokolování</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>Povoleno</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>Zakázáno</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>Povolit objemné záznamy úrovní Debug a Trace v denních souborech protokolu pouze pro toto spuštění; po restartu se tato volba vypne.</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>Denní soubory protokolu obsahují objemné záznamy úrovní Debug a Trace, dokud tuto volbu nevypnete nebo se rozšíření nerestartuje.</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>Uložit diagnostické protokoly na plochu</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.de-DE.resx
+++ b/src/MediaControlsExtension/Resources/Strings.de-DE.resx
@@ -561,6 +561,27 @@ Besonderer Dank gilt [Mike Griese](https://github.com/zadjii-msft)</value>
 
 Diagnoseprotokolle können Medientitel, Playernamen und technische Fehlerdetails enthalten. Überprüfen Sie das Archiv, bevor Sie es weitergeben.</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>Aktivieren</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>Deaktivieren</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>Detaillierte Protokollierung</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>Aktiviert</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>Deaktiviert</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>Debug- und Trace-Einträge mit hohem Datenaufkommen nur für diese Ausführung in den täglichen Protokolldateien aktivieren; die Option wird beim Neustart zurückgesetzt.</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>Die täglichen Protokolldateien enthalten Debug- und Trace-Einträge mit hohem Datenaufkommen, bis Sie die Option deaktivieren oder die Erweiterung neu gestartet wird.</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>Diagnoseprotokolle auf dem Desktop speichern</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.es-ES.resx
+++ b/src/MediaControlsExtension/Resources/Strings.es-ES.resx
@@ -561,6 +561,27 @@ Agradecimiento especial a [Mike Griese](https://github.com/zadjii-msft)</value>
 
 Los registros de diagnóstico pueden contener títulos multimedia, nombres de reproductores y detalles técnicos de errores. Revise el archivo antes de compartirlo.</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>Activar</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>Desactivar</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>Registro detallado</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>Activado</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>Desactivado</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>Activa las entradas Debug y Trace de gran volumen en los archivos de registro diarios solo durante esta ejecución; la opción se restablece al reiniciar.</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>Los archivos de registro diarios incluyen entradas Debug y Trace de gran volumen hasta que desactive la opción o se reinicie la extensión.</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>Guardar registros de diagnóstico en el escritorio</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.fr-FR.resx
+++ b/src/MediaControlsExtension/Resources/Strings.fr-FR.resx
@@ -561,6 +561,27 @@ Remerciements particuliers à [Mike Griese](https://github.com/zadjii-msft)</val
 
 Les journaux de diagnostic peuvent contenir des titres de médias, des noms de lecteurs et des détails techniques sur les erreurs. Vérifiez l’archive avant de la partager.</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>Activer</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>Désactiver</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>Journalisation détaillée</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>Activée</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>Désactivée</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>Activer les entrées Debug et Trace à volume élevé dans les fichiers journaux quotidiens uniquement pour cette exécution ; l’option est réinitialisée au redémarrage.</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>Les fichiers journaux quotidiens incluent les entrées Debug et Trace à volume élevé jusqu’à ce que vous désactiviez l’option ou que l’extension redémarre.</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>Enregistrer les journaux de diagnostic sur le Bureau</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.it-IT.resx
+++ b/src/MediaControlsExtension/Resources/Strings.it-IT.resx
@@ -561,6 +561,27 @@ Un ringraziamento speciale a [Mike Griese](https://github.com/zadjii-msft)</valu
 
 I log di diagnostica possono contenere titoli dei contenuti multimediali, nomi dei lettori e dettagli tecnici sugli errori. Controlla l’archivio prima di condividerlo.</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>Abilita</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>Disabilita</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>Registrazione dettagliata</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>Abilitata</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>Disabilitata</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>Abilita le voci Debug e Trace ad alto volume nei file di log giornalieri solo per questa esecuzione; l’opzione viene reimpostata al riavvio.</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>I file di log giornalieri includono le voci Debug e Trace ad alto volume finché l’opzione non viene disattivata o l’estensione non viene riavviata.</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>Salva i log di diagnostica sul desktop</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.ja-JP.resx
+++ b/src/MediaControlsExtension/Resources/Strings.ja-JP.resx
@@ -561,6 +561,27 @@ _Copyright © Jiří Polášek_
 
 診断ログには、メディアのタイトル、プレーヤー名、技術的なエラーの詳細が含まれる場合があります。共有する前にアーカイブの内容を確認してください。</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>有効にする</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>無効にする</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>詳細ログ</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>有効</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>無効</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>今回の実行中のみ、日次ログ ファイルに大量の Debug および Trace エントリを記録します。このオプションは再起動するとリセットされます。</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>このオプションを無効にするか拡張機能を再起動するまで、日次ログ ファイルに大量の Debug および Trace エントリが記録されます。</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>診断ログをデスクトップに保存</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.ko-KR.resx
+++ b/src/MediaControlsExtension/Resources/Strings.ko-KR.resx
@@ -561,6 +561,27 @@ _저작권 © Jiří Polášek_
 
 진단 로그에는 미디어 제목, 플레이어 이름 및 기술적인 오류 세부 정보가 포함될 수 있습니다. 공유하기 전에 보관 파일을 검토하세요.</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>사용</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>사용 안 함</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>상세 로깅</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>사용 중</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>사용 안 함</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>이번 실행 중에만 일별 로그 파일에 대량의 Debug 및 Trace 항목을 기록합니다. 다시 시작하면 이 옵션이 초기화됩니다.</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>이 옵션을 끄거나 확장이 다시 시작될 때까지 일별 로그 파일에 대량의 Debug 및 Trace 항목이 포함됩니다.</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>진단 로그를 바탕 화면에 저장</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.nl-NL.resx
+++ b/src/MediaControlsExtension/Resources/Strings.nl-NL.resx
@@ -561,6 +561,27 @@ Met speciale dank aan [Mike Griese](https://github.com/zadjii-msft)</value>
 
 Diagnostische logboeken kunnen mediatitels, namen van mediaspelers en technische foutgegevens bevatten. Controleer het archief voordat u het deelt.</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>Inschakelen</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>Uitschakelen</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>Gedetailleerde logboekregistratie</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>Ingeschakeld</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>Uitgeschakeld</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>Schakel grote aantallen Debug- en Trace-vermeldingen alleen voor deze uitvoering in de dagelijkse logboekbestanden in; de optie wordt bij opnieuw starten hersteld.</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>De dagelijkse logboekbestanden bevatten grote aantallen Debug- en Trace-vermeldingen totdat u de optie uitschakelt of de extensie opnieuw wordt gestart.</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>Diagnostische logboeken op het bureaublad opslaan</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.pl-PL.resx
+++ b/src/MediaControlsExtension/Resources/Strings.pl-PL.resx
@@ -561,6 +561,27 @@ Szczególne podziękowania dla [Mike'a Griese'a](https://github.com/zadjii-msft)
 
 Dzienniki diagnostyczne mogą zawierać tytuły multimediów, nazwy odtwarzaczy i techniczne szczegóły błędów. Przed udostępnieniem przejrzyj zawartość archiwum.</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>Włącz</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>Wyłącz</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>Szczegółowe rejestrowanie</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>Włączone</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>Wyłączone</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>Włącz dużą liczbę wpisów Debug i Trace w codziennych plikach dziennika tylko dla tego uruchomienia; opcja zostanie zresetowana po ponownym uruchomieniu.</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>Codzienne pliki dziennika zawierają dużą liczbę wpisów Debug i Trace do czasu wyłączenia opcji lub ponownego uruchomienia rozszerzenia.</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>Zapisz dzienniki diagnostyczne na pulpicie</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.pt-BR.resx
+++ b/src/MediaControlsExtension/Resources/Strings.pt-BR.resx
@@ -561,6 +561,27 @@ Agradecimentos especiais a [Mike Griese](https://github.com/zadjii-msft)</value>
 
 Os logs de diagnóstico podem conter títulos de mídia, nomes de reprodutores e detalhes técnicos de erros. Revise o arquivo antes de compartilhá-lo.</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>Ativar</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>Desativar</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>Registro detalhado</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>Ativado</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>Desativado</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>Ative entradas Debug e Trace de alto volume nos arquivos de log diários somente nesta execução; a opção é redefinida ao reiniciar.</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>Os arquivos de log diários incluem entradas Debug e Trace de alto volume até que você desative a opção ou a extensão seja reiniciada.</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>Salvar logs de diagnóstico na Área de Trabalho</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.pt-PT.resx
+++ b/src/MediaControlsExtension/Resources/Strings.pt-PT.resx
@@ -561,6 +561,27 @@ Agradecimentos especiais a [Mike Griese](https://github.com/zadjii-msft)</value>
 
 Os registos de diagnóstico podem conter títulos multimédia, nomes de leitores e detalhes técnicos de erros. Reveja o conteúdo do ficheiro antes de o partilhar.</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>Ativar</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>Desativar</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>Registo detalhado</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>Ativado</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>Desativado</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>Ative entradas Debug e Trace de elevado volume nos ficheiros de registo diários apenas nesta execução; a opção é reposta ao reiniciar.</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>Os ficheiros de registo diários incluem entradas Debug e Trace de elevado volume até desativar a opção ou reiniciar a extensão.</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>Guardar registos de diagnóstico no Ambiente de Trabalho</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.resx
+++ b/src/MediaControlsExtension/Resources/Strings.resx
@@ -589,6 +589,27 @@ Special thanks to [Mike Griese](https://github.com/zadjii-msft)</value>
 
 Diagnostic logs can contain media titles, player names, and technical error details. Review the archive before sharing it.</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>Enable</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>Disable</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>Detailed logging</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>Enable high-volume Debug and Trace entries in daily log files for this run only; the option resets on restart.</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>Daily log files include high-volume Debug and Trace entries until the option is disabled or the extension restarts.</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>Save diagnostic logs to Desktop</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.zh-CN.resx
+++ b/src/MediaControlsExtension/Resources/Strings.zh-CN.resx
@@ -561,6 +561,27 @@ _版权所有 © Jiří Polášek_
 
 诊断日志可能包含媒体标题、播放器名称和技术错误详细信息。共享前请检查压缩包内容。</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>启用</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>禁用</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>详细日志记录</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>已启用</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>已禁用</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>仅在本次运行期间将大量 Debug 和 Trace 条目写入每日日志文件；重启后此选项会重置。</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>在关闭此选项或扩展重启之前，每日日志文件会包含大量 Debug 和 Trace 条目。</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>将诊断日志保存到桌面</value>
   </data>

--- a/src/MediaControlsExtension/Resources/Strings.zh-TW.resx
+++ b/src/MediaControlsExtension/Resources/Strings.zh-TW.resx
@@ -561,6 +561,27 @@ _版權所有 © Jiří Polášek_
 
 診斷記錄檔可能包含媒體標題、播放器名稱及技術錯誤詳細資料。分享前請先檢查壓縮檔內容。</value>
   </data>
+  <data name="ReportProblem_DetailedLogging_Enable_Title" xml:space="preserve">
+    <value>啟用</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disable_Title" xml:space="preserve">
+    <value>停用</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Title" xml:space="preserve">
+    <value>詳細記錄</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Label" xml:space="preserve">
+    <value>已啟用</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Label" xml:space="preserve">
+    <value>已停用</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Disabled_Subtitle" xml:space="preserve">
+    <value>只在本次執行期間將大量 Debug 和 Trace 項目寫入每日記錄檔；重新啟動後此選項會重設。</value>
+  </data>
+  <data name="ReportProblem_DetailedLogging_Enabled_Subtitle" xml:space="preserve">
+    <value>在關閉此選項或擴充功能重新啟動之前，每日記錄檔會包含大量 Debug 和 Trace 項目。</value>
+  </data>
   <data name="ReportProblem_SaveLogs_Title" xml:space="preserve">
     <value>將診斷記錄檔儲存到桌面</value>
   </data>

--- a/src/MediaControlsExtension/Services/DetailedLoggingMode.cs
+++ b/src/MediaControlsExtension/Services/DetailedLoggingMode.cs
@@ -1,0 +1,44 @@
+// ------------------------------------------------------------
+//
+// Copyright (c) Jiří Polášek. All rights reserved.
+//
+// ------------------------------------------------------------
+
+namespace JPSoftworks.MediaControlsExtension.Services;
+
+internal static class DetailedLoggingMode
+{
+    // Process-local by design; explicit debug launches seed this as enabled.
+    private static int _enabled;
+
+    public static bool IsEnabled
+        => Volatile.Read(ref _enabled) != 0;
+
+    public static void InitializeForProcess(bool enabled)
+    {
+        Volatile.Write(ref _enabled, enabled ? 1 : 0);
+    }
+
+    public static bool ShouldWriteToFile(LogLevel logLevel)
+    {
+        return logLevel is >= LogLevel.Trace and < LogLevel.None &&
+               (IsEnabled || logLevel >= LogLevel.Information);
+    }
+
+    public static bool Toggle()
+    {
+        int currentState;
+        int newState;
+        do
+        {
+            currentState = Volatile.Read(ref _enabled);
+            newState = currentState == 0 ? 1 : 0;
+        }
+        while (Interlocked.CompareExchange(
+                   ref _enabled,
+                   newState,
+                   currentState) != currentState);
+
+        return newState != 0;
+    }
+}

--- a/tests/MediaControlsExtension.Media.Tests/Infrastructure/FakeMediaBackend.cs
+++ b/tests/MediaControlsExtension.Media.Tests/Infrastructure/FakeMediaBackend.cs
@@ -15,7 +15,9 @@ internal sealed class FakeMediaBackend(MediaBackendSnapshot initialSnapshot) : I
 {
     private readonly TaskCompletionSource _commandStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource _releaseCommands = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _releaseSnapshotReads = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource _releaseStart = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _snapshotReadStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource _startStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly Channel<MediaBackendSignal> _signals = Channel.CreateBounded<MediaBackendSignal>(
         new BoundedChannelOptions(1)
@@ -29,6 +31,7 @@ internal sealed class FakeMediaBackend(MediaBackendSnapshot initialSnapshot) : I
     private readonly List<ImmutableArray<MediaBackendObservationRequest>> _observationInvalidations = [];
     private MediaBackendSnapshot _snapshot = initialSnapshot;
     private int _blockCommands;
+    private int _blockSnapshotReads;
     private int _blockStart;
     private int _disposeCount;
     private int _snapshotReadCount;
@@ -42,6 +45,8 @@ internal sealed class FakeMediaBackend(MediaBackendSnapshot initialSnapshot) : I
     public int DisposeCount => Volatile.Read(ref this._disposeCount);
 
     public int SnapshotReadCount => Volatile.Read(ref this._snapshotReadCount);
+
+    public Task SnapshotReadStarted => this._snapshotReadStarted.Task;
 
     public Task StartStarted => this._startStarted.Task;
 
@@ -79,7 +84,22 @@ internal sealed class FakeMediaBackend(MediaBackendSnapshot initialSnapshot) : I
     public void SetSnapshot(MediaBackendSnapshot snapshot)
     {
         this.SetSnapshotWithoutSignal(snapshot);
-        this._signals.Writer.TryWrite(MediaBackendSignal.StateChanged);
+        this.Signal(MediaBackendSignal.ObservationsChanged);
+    }
+
+    public void BlockSnapshotReads()
+    {
+        Volatile.Write(ref this._blockSnapshotReads, 1);
+    }
+
+    public void ReleaseSnapshotReads()
+    {
+        this._releaseSnapshotReads.TrySetResult();
+    }
+
+    public void Signal(MediaBackendSignal signal)
+    {
+        this._signals.Writer.TryWrite(signal);
     }
 
     public void SetSnapshotWithoutSignal(MediaBackendSnapshot snapshot)
@@ -99,7 +119,10 @@ internal sealed class FakeMediaBackend(MediaBackendSnapshot initialSnapshot) : I
         }
 
         cancellationToken.ThrowIfCancellationRequested();
-        this._signals.Writer.TryWrite(MediaBackendSignal.StateChanged);
+        this.Signal(
+            MediaBackendSignal.ObservationsChanged |
+            MediaBackendSignal.SessionsChanged |
+            MediaBackendSignal.CurrentSessionChanged);
     }
 
     public async IAsyncEnumerable<MediaBackendSignal> WatchAsync(
@@ -111,13 +134,19 @@ internal sealed class FakeMediaBackend(MediaBackendSnapshot initialSnapshot) : I
         }
     }
 
-    public Task<MediaBackendSnapshot> ReadSnapshotAsync(CancellationToken cancellationToken)
+    public async Task<MediaBackendSnapshot> ReadSnapshotAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         Interlocked.Increment(ref this._snapshotReadCount);
+        if (Volatile.Read(ref this._blockSnapshotReads) != 0)
+        {
+            this._snapshotReadStarted.TrySetResult();
+            await this._releaseSnapshotReads.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
         lock (this._stateLock)
         {
-            return Task.FromResult(this._snapshot);
+            return this._snapshot;
         }
     }
 
@@ -156,6 +185,7 @@ internal sealed class FakeMediaBackend(MediaBackendSnapshot initialSnapshot) : I
         Interlocked.Increment(ref this._disposeCount);
         this._signals.Writer.TryComplete();
         this._releaseCommands.TrySetResult();
+        this._releaseSnapshotReads.TrySetResult();
         this._releaseStart.TrySetResult();
         return ValueTask.CompletedTask;
     }

--- a/tests/MediaControlsExtension.Media.Tests/MediaRefreshRegulatorTests.cs
+++ b/tests/MediaControlsExtension.Media.Tests/MediaRefreshRegulatorTests.cs
@@ -1,0 +1,158 @@
+// ------------------------------------------------------------
+//
+// Copyright (c) Jiří Polášek. All rights reserved.
+//
+// ------------------------------------------------------------
+
+namespace JPSoftworks.MediaControlsExtension.Media.Tests;
+
+[TestClass]
+public sealed class MediaRefreshRegulatorTests
+{
+    private static readonly MediaRefreshPolicy Policy = new(
+        TimeSpan.FromMilliseconds(50),
+        TimeSpan.FromMilliseconds(250),
+        TimeSpan.FromSeconds(1),
+        3,
+        2);
+
+    [TestMethod]
+    public void NotificationsDoNotConsumeBurstCreditsUntilARefreshExecutes()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var regulator = new MediaRefreshRegulator(timeProvider, Policy);
+
+        regulator.RegisterRequest(timeProvider.GetTimestamp());
+        for (var index = 0; index < 100; index++)
+        {
+            regulator.RegisterRequest(timeProvider.GetTimestamp());
+        }
+
+        var admission = regulator.GetAdmission(
+            timeProvider.GetTimestamp(),
+            MediaRefreshReason.ObservationsChanged);
+
+        Assert.AreEqual(MediaRefreshMode.Burst, admission.Mode);
+        Assert.AreEqual(3, admission.BurstCredits);
+        Assert.AreEqual(TimeSpan.Zero, admission.Delay);
+    }
+
+    [TestMethod]
+    public void TopologyCreditsCoverTeardownAfterTheGeneralBurstIsExhausted()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var regulator = new MediaRefreshRegulator(timeProvider, Policy);
+
+        for (var index = 0; index < Policy.BurstCapacity; index++)
+        {
+            regulator.RegisterRequest(timeProvider.GetTimestamp());
+            var burstAdmission = regulator.GetAdmission(
+                timeProvider.GetTimestamp(),
+                MediaRefreshReason.ObservationsChanged);
+            Assert.AreEqual(MediaRefreshMode.Burst, burstAdmission.Mode);
+            regulator.RegisterExecution(
+                timeProvider.GetTimestamp(),
+                MediaRefreshReason.ObservationsChanged);
+            timeProvider.Advance(Policy.BurstInterval);
+        }
+
+        regulator.RegisterRequest(timeProvider.GetTimestamp());
+        var sustainedAdmission = regulator.GetAdmission(
+            timeProvider.GetTimestamp(),
+            MediaRefreshReason.ObservationsChanged);
+        Assert.AreEqual(MediaRefreshMode.Sustained, sustainedAdmission.Mode);
+        Assert.AreEqual(TimeSpan.FromMilliseconds(200), sustainedAdmission.Delay);
+
+        regulator.RegisterRequest(timeProvider.GetTimestamp());
+        var firstTopologyAdmission = regulator.GetAdmission(
+            timeProvider.GetTimestamp(),
+            MediaRefreshReason.SessionsChanged);
+        Assert.AreEqual(MediaRefreshMode.Burst, firstTopologyAdmission.Mode);
+        Assert.AreEqual(TimeSpan.Zero, firstTopologyAdmission.Delay);
+        regulator.RegisterExecution(
+            timeProvider.GetTimestamp(),
+            MediaRefreshReason.SessionsChanged);
+
+        timeProvider.Advance(Policy.BurstInterval);
+        regulator.RegisterRequest(timeProvider.GetTimestamp());
+        var secondTopologyAdmission = regulator.GetAdmission(
+            timeProvider.GetTimestamp(),
+            MediaRefreshReason.CurrentSessionChanged);
+        Assert.AreEqual(MediaRefreshMode.Burst, secondTopologyAdmission.Mode);
+        regulator.RegisterExecution(
+            timeProvider.GetTimestamp(),
+            MediaRefreshReason.CurrentSessionChanged);
+
+        timeProvider.Advance(Policy.BurstInterval);
+        regulator.RegisterRequest(timeProvider.GetTimestamp());
+        var exhaustedAdmission = regulator.GetAdmission(
+            timeProvider.GetTimestamp(),
+            MediaRefreshReason.SessionsChanged);
+        Assert.AreEqual(MediaRefreshMode.Sustained, exhaustedAdmission.Mode);
+        Assert.AreEqual(TimeSpan.FromMilliseconds(200), exhaustedAdmission.Delay);
+    }
+
+    [TestMethod]
+    public void TopologyDuringTheGeneralBurstDoesNotSpendTheReserve()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var regulator = new MediaRefreshRegulator(timeProvider, Policy);
+
+        regulator.RegisterRequest(timeProvider.GetTimestamp());
+        regulator.RegisterExecution(
+            timeProvider.GetTimestamp(),
+            MediaRefreshReason.SessionsChanged);
+
+        var admission = regulator.GetAdmission(
+            timeProvider.GetTimestamp(),
+            MediaRefreshReason.CurrentSessionChanged);
+
+        Assert.AreEqual(Policy.BurstCapacity - 1, admission.BurstCredits);
+        Assert.AreEqual(
+            Policy.TopologyBurstCapacity,
+            admission.TopologyBurstCredits);
+    }
+
+    [TestMethod]
+    public void QuietPeriodRestoresBothBurstBudgets()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var regulator = new MediaRefreshRegulator(timeProvider, Policy);
+
+        regulator.RegisterRequest(timeProvider.GetTimestamp());
+        for (var index = 0; index < Policy.BurstCapacity; index++)
+        {
+            regulator.RegisterExecution(
+                timeProvider.GetTimestamp(),
+                MediaRefreshReason.ObservationsChanged);
+            timeProvider.Advance(Policy.BurstInterval);
+            regulator.RegisterRequest(timeProvider.GetTimestamp());
+        }
+
+        timeProvider.Advance(Policy.QuietPeriod);
+        var startsNewBurst = regulator.RegisterRequest(timeProvider.GetTimestamp());
+        var admission = regulator.GetAdmission(
+            timeProvider.GetTimestamp(),
+            MediaRefreshReason.SessionsChanged);
+
+        Assert.IsTrue(startsNewBurst);
+        Assert.AreEqual(MediaRefreshMode.Burst, admission.Mode);
+        Assert.AreEqual(Policy.BurstCapacity, admission.BurstCredits);
+        Assert.AreEqual(Policy.TopologyBurstCapacity, admission.TopologyBurstCredits);
+        Assert.AreEqual(TimeSpan.Zero, admission.Delay);
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => Interlocked.Read(ref this._timestamp);
+
+        public void Advance(TimeSpan elapsed)
+        {
+            Interlocked.Add(ref this._timestamp, elapsed.Ticks);
+        }
+    }
+}

--- a/tests/MediaControlsExtension.Media.Tests/MediaServiceConcurrencyTests.cs
+++ b/tests/MediaControlsExtension.Media.Tests/MediaServiceConcurrencyTests.cs
@@ -5,6 +5,7 @@
 // ------------------------------------------------------------
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using JPSoftworks.MediaControlsExtension.Media.Infrastructure;
 using JPSoftworks.MediaControlsExtension.Media.Tests.Infrastructure;
 
@@ -13,6 +14,71 @@ namespace JPSoftworks.MediaControlsExtension.Media.Tests;
 [TestClass]
 public sealed class MediaServiceConcurrencyTests
 {
+    [TestMethod]
+    public async Task TopologySignalInterruptsAQueuedSustainedRefresh()
+    {
+        var backend = new FakeMediaBackend(FakeMediaBackend.CreateSnapshot(1, "Initial"));
+        var refreshPolicy = new MediaRefreshPolicy(
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(30),
+            1,
+            1);
+        await using var service = new MediaService(
+            backend,
+            refreshPolicy: refreshPolicy);
+        await service.StartAsync();
+        await WaitUntilSnapshotReadsSettleAsync(backend);
+        var baselineReadCount = backend.SnapshotReadCount;
+        backend.BlockSnapshotReads();
+
+        backend.Signal(MediaBackendSignal.ObservationsChanged);
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+        Assert.AreEqual(baselineReadCount, backend.SnapshotReadCount);
+
+        backend.Signal(MediaBackendSignal.SessionsChanged);
+        await backend.SnapshotReadStarted.WaitAsync(TimeSpan.FromMilliseconds(500));
+        Assert.AreEqual(baselineReadCount + 1, backend.SnapshotReadCount);
+        backend.ReleaseSnapshotReads();
+    }
+
+    [TestMethod]
+    public async Task SustainedNotificationsProduceOneRateLimitedTrailingRefresh()
+    {
+        var backend = new FakeMediaBackend(FakeMediaBackend.CreateSnapshot(1, "Initial"));
+        var refreshPolicy = new MediaRefreshPolicy(
+            TimeSpan.Zero,
+            TimeSpan.FromMilliseconds(150),
+            TimeSpan.FromSeconds(30),
+            1,
+            0);
+        await using var service = new MediaService(
+            backend,
+            refreshPolicy: refreshPolicy);
+        await service.StartAsync();
+        await WaitUntilSnapshotReadsSettleAsync(backend);
+        var baselineReadCount = backend.SnapshotReadCount;
+        backend.BlockSnapshotReads();
+
+        backend.Signal(MediaBackendSignal.ObservationsChanged);
+        await backend.SnapshotReadStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.AreEqual(baselineReadCount + 1, backend.SnapshotReadCount);
+
+        for (var index = 0; index < 100; index++)
+        {
+            backend.Signal(MediaBackendSignal.ObservationsChanged);
+        }
+
+        await Task.Delay(TimeSpan.FromMilliseconds(25));
+        backend.ReleaseSnapshotReads();
+        await Task.Delay(TimeSpan.FromMilliseconds(75));
+        Assert.AreEqual(baselineReadCount + 1, backend.SnapshotReadCount);
+
+        await WaitUntilAsync(() => backend.SnapshotReadCount == baselineReadCount + 2);
+        await Task.Delay(TimeSpan.FromMilliseconds(200));
+        Assert.AreEqual(baselineReadCount + 2, backend.SnapshotReadCount);
+    }
+
     [TestMethod]
     public async Task CanceledReadinessWaitCompletesDequeuedCommand()
     {
@@ -593,16 +659,22 @@ public sealed class MediaServiceConcurrencyTests
     {
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var previousCount = backend.SnapshotReadCount;
+        var stableSince = Stopwatch.GetTimestamp();
         while (true)
         {
             await Task.Delay(TimeSpan.FromMilliseconds(25), timeout.Token);
             var currentCount = backend.SnapshotReadCount;
-            if (currentCount == previousCount)
+            if (currentCount != previousCount)
+            {
+                previousCount = currentCount;
+                stableSince = Stopwatch.GetTimestamp();
+                continue;
+            }
+
+            if (Stopwatch.GetElapsedTime(stableSince) >= TimeSpan.FromMilliseconds(300))
             {
                 return;
             }
-
-            previousCount = currentCount;
         }
     }
 


### PR DESCRIPTION
- Regulates and coalesce GSMTC refresh activity.
- Adds session churn and native-call diagnostics.
- Keeps verbose logs file-only behind a per-run toggle.
- Limits Command Palette logging to critical events.