### PR TITLE
Preserve media sessions during transient GSMTC recreation

### DIFF
--- a/src/MediaControlsExtension.Media/Abstractions/MediaSession.cs
+++ b/src/MediaControlsExtension.Media/Abstractions/MediaSession.cs
@@ -26,7 +26,7 @@ public sealed class MediaSession
         this._bindingGeneration = snapshot.BindingGeneration;
         this._state = new(
             1,
-            true,
+            snapshot.IsAvailable,
             snapshot.MediaProperties,
             snapshot.TimelineProperties,
             snapshot.PlaybackInfo);
@@ -77,7 +77,7 @@ public sealed class MediaSession
             changes |= MediaSessionChanges.PlaybackInfo;
         }
 
-        if (!previous.IsAvailable)
+        if (snapshot.IsAvailable != previous.IsAvailable)
         {
             changes |= MediaSessionChanges.Availability;
         }
@@ -97,7 +97,7 @@ public sealed class MediaSession
             ref this._state,
             new(
                 previous.Revision + 1,
-                true,
+                snapshot.IsAvailable,
                 mediaProperties,
                 timelineProperties,
                 playbackInfo));

--- a/src/MediaControlsExtension.Media/Abstractions/MediaSnapshots.cs
+++ b/src/MediaControlsExtension.Media/Abstractions/MediaSnapshots.cs
@@ -164,6 +164,7 @@ internal sealed record MediaServiceState(
 internal sealed record MediaSessionSnapshot(
     MediaSessionId Id,
     long BindingGeneration,
+    bool IsAvailable,
     MediaPropertiesSnapshot MediaProperties,
     MediaTimelinePropertiesSnapshot TimelineProperties,
     MediaPlaybackInfoSnapshot PlaybackInfo);

--- a/src/MediaControlsExtension.Media/Diagnostics/MediaLog.cs
+++ b/src/MediaControlsExtension.Media/Diagnostics/MediaLog.cs
@@ -194,4 +194,21 @@ internal static partial class MediaLog
         long callId,
         string operation,
         TimeSpan elapsed);
+
+    [LoggerMessage(EventId = 29, Level = LogLevel.Debug, Message = "Retaining missing GSMTC session {ApplicationId} for {GracePeriod} while waiting for recreation.")]
+    public static partial void SessionRetentionStarted(
+        ILogger logger,
+        string applicationId,
+        TimeSpan gracePeriod);
+
+    [LoggerMessage(EventId = 30, Level = LogLevel.Information, Message = "Measured a transient GSMTC absence for application {ApplicationId}; future unambiguous removals receive up to {GracePeriod} of grace.")]
+    public static partial void SessionRecreationGraceIncreased(
+        ILogger logger,
+        string applicationId,
+        TimeSpan gracePeriod);
+
+    [LoggerMessage(EventId = 31, Level = LogLevel.Debug, Message = "GSMTC session {ApplicationId} did not return within its retention grace.")]
+    public static partial void SessionRetentionExpired(
+        ILogger logger,
+        string applicationId);
 }

--- a/src/MediaControlsExtension.Media/Infrastructure/Gsmtc/AdaptiveSessionRetentionPolicy.cs
+++ b/src/MediaControlsExtension.Media/Infrastructure/Gsmtc/AdaptiveSessionRetentionPolicy.cs
@@ -1,0 +1,219 @@
+// ------------------------------------------------------------
+//
+// Copyright (c) Jiří Polášek. All rights reserved.
+//
+// ------------------------------------------------------------
+
+namespace JPSoftworks.MediaControlsExtension.Media.Infrastructure.Gsmtc;
+
+internal enum SessionRecreationEvidence
+{
+    Weak,
+    Strong,
+}
+
+/// <summary>
+/// Learns which application identities recreate their native GSMTC sessions and
+/// grants only those identities a longer transient-removal grace period.
+/// </summary>
+internal sealed class AdaptiveSessionRetentionPolicy
+{
+    private const int LearnedEvidenceThreshold = 2;
+    private const int MaximumProfileCount = 64;
+
+    private static readonly TimeSpan DefaultProbeGracePeriod = TimeSpan.FromMilliseconds(400);
+    private static readonly TimeSpan DefaultMaximumGracePeriod = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan DefaultRecentRemovalWindow = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan DefaultEvidenceLifetime = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan ObservedGapMinimumMargin = TimeSpan.FromMilliseconds(250);
+
+    private readonly TimeSpan _evidenceLifetime;
+    private readonly TimeSpan _maximumGracePeriod;
+    private readonly Lock _stateLock = new();
+    private readonly TimeSpan _probeGracePeriod;
+    private readonly Dictionary<string, RecreationProfile> _profiles =
+        new(StringComparer.Ordinal);
+
+    public AdaptiveSessionRetentionPolicy()
+        : this(
+            DefaultProbeGracePeriod,
+            DefaultMaximumGracePeriod,
+            DefaultRecentRemovalWindow,
+            DefaultEvidenceLifetime)
+    {
+    }
+
+    internal AdaptiveSessionRetentionPolicy(
+        TimeSpan probeGracePeriod,
+        TimeSpan maximumGracePeriod,
+        TimeSpan recentRemovalWindow,
+        TimeSpan evidenceLifetime)
+    {
+        ValidatePositive(probeGracePeriod, nameof(probeGracePeriod));
+        ValidatePositive(maximumGracePeriod, nameof(maximumGracePeriod));
+        ValidatePositive(recentRemovalWindow, nameof(recentRemovalWindow));
+        ValidatePositive(evidenceLifetime, nameof(evidenceLifetime));
+        if (maximumGracePeriod < probeGracePeriod)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maximumGracePeriod),
+                maximumGracePeriod,
+                "The maximum grace period must not be shorter than the probe grace period.");
+        }
+
+        this._probeGracePeriod = probeGracePeriod;
+        this._maximumGracePeriod = maximumGracePeriod;
+        this.RecentRemovalWindow = recentRemovalWindow;
+        this._evidenceLifetime = evidenceLifetime;
+    }
+
+    public TimeSpan RecentRemovalWindow { get; }
+
+    public TimeSpan GetGracePeriod(
+        string applicationId,
+        TimeSpan now,
+        bool isUnambiguous)
+    {
+        if (!isUnambiguous || string.IsNullOrWhiteSpace(applicationId))
+        {
+            return this._probeGracePeriod;
+        }
+
+        lock (this._stateLock)
+        {
+            if (!this.TryGetCurrentProfileUnderLock(applicationId, now, out var profile))
+            {
+                return this._probeGracePeriod;
+            }
+
+            return profile.Evidence >= LearnedEvidenceThreshold
+                ? profile.GracePeriod
+                : this._probeGracePeriod;
+        }
+    }
+
+    public bool RecordRecreation(
+        string applicationId,
+        SessionRecreationEvidence evidence,
+        TimeSpan? missingDuration,
+        TimeSpan now)
+    {
+        if (string.IsNullOrWhiteSpace(applicationId))
+        {
+            return false;
+        }
+
+        lock (this._stateLock)
+        {
+            var wasLearned = this.TryGetCurrentProfileUnderLock(
+                applicationId,
+                now,
+                out var profile) &&
+                profile.Evidence >= LearnedEvidenceThreshold;
+            var previousGracePeriod = wasLearned
+                ? profile.GracePeriod
+                : this._probeGracePeriod;
+            var evidenceValue = evidence == SessionRecreationEvidence.Strong
+                ? LearnedEvidenceThreshold
+                : 1;
+            var observedGracePeriod = missingDuration is { } duration
+                ? this.CalculateObservedGracePeriod(duration)
+                : this._probeGracePeriod;
+            var updatedEvidence = Math.Min(
+                LearnedEvidenceThreshold,
+                profile.Evidence + evidenceValue);
+            var updatedGracePeriod = profile.GracePeriod > observedGracePeriod
+                ? profile.GracePeriod
+                : observedGracePeriod;
+            this._profiles[applicationId] = new(
+                updatedEvidence,
+                updatedGracePeriod,
+                now);
+
+            if (this._profiles.Count > MaximumProfileCount)
+            {
+                this.RemoveExpiredProfilesUnderLock(now);
+                while (this._profiles.Count > MaximumProfileCount)
+                {
+                    var oldestApplicationId = this._profiles.MinBy(
+                        static profile => profile.Value.LastEvidence).Key;
+                    this._profiles.Remove(oldestApplicationId);
+                }
+            }
+
+            var effectiveGracePeriod = updatedEvidence >= LearnedEvidenceThreshold
+                ? updatedGracePeriod
+                : this._probeGracePeriod;
+            return effectiveGracePeriod > previousGracePeriod;
+        }
+    }
+
+    private bool TryGetCurrentProfileUnderLock(
+        string applicationId,
+        TimeSpan now,
+        out RecreationProfile profile)
+    {
+        if (!this._profiles.TryGetValue(applicationId, out profile))
+        {
+            return false;
+        }
+
+        if (now - profile.LastEvidence < this._evidenceLifetime)
+        {
+            return true;
+        }
+
+        this._profiles.Remove(applicationId);
+        profile = default;
+        return false;
+    }
+
+    private void RemoveExpiredProfilesUnderLock(TimeSpan now)
+    {
+        foreach (var (applicationId, profile) in this._profiles.ToArray())
+        {
+            if (now - profile.LastEvidence >= this._evidenceLifetime)
+            {
+                this._profiles.Remove(applicationId);
+            }
+        }
+    }
+
+    private TimeSpan CalculateObservedGracePeriod(TimeSpan missingDuration)
+    {
+        if (missingDuration < TimeSpan.Zero)
+        {
+            missingDuration = TimeSpan.Zero;
+        }
+
+        var proportionalMargin = TimeSpan.FromTicks(missingDuration.Ticks / 2);
+        var margin = proportionalMargin > ObservedGapMinimumMargin
+            ? proportionalMargin
+            : ObservedGapMinimumMargin;
+        var gracePeriod = missingDuration + margin;
+        if (gracePeriod < this._probeGracePeriod)
+        {
+            return this._probeGracePeriod;
+        }
+
+        return gracePeriod < this._maximumGracePeriod
+            ? gracePeriod
+            : this._maximumGracePeriod;
+    }
+
+    private static void ValidatePositive(TimeSpan value, string parameterName)
+    {
+        if (value <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                value,
+                "The duration must be positive.");
+        }
+    }
+
+    private readonly record struct RecreationProfile(
+        int Evidence,
+        TimeSpan GracePeriod,
+        TimeSpan LastEvidence);
+}

--- a/src/MediaControlsExtension.Media/Infrastructure/Gsmtc/GsmtcBackend.cs
+++ b/src/MediaControlsExtension.Media/Infrastructure/Gsmtc/GsmtcBackend.cs
@@ -57,10 +57,30 @@ internal sealed class GsmtcBackend : IMediaBackend
         string Path,
         MediaBackendSessionId? CurrentSessionId);
 
+    private readonly record struct ObservedSession(
+        GlobalSystemMediaTransportControlsSession Session,
+        string ApplicationId);
+
+    private readonly record struct RecentSessionBinding(
+        SessionBinding Binding,
+        TimeSpan ExpiresAt);
+
+    private readonly record struct MissingSessionRetention(
+        long Version);
+
+    private enum RetentionExpiryStatus
+    {
+        Inactive,
+        Waiting,
+        Expired,
+    }
+
     private readonly GsmtcControlGate _controlGate;
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly ILogger _logger;
     private readonly GsmtcObservationGate _observationGate;
+    private readonly List<RecentSessionBinding> _recentlyRemovedBindings = [];
+    private readonly AdaptiveSessionRetentionPolicy _sessionRetentionPolicy = new();
     private readonly Channel<bool> _signals;
     private readonly Lock _stateLock = new();
     private readonly Dictionary<MediaBackendSessionId, SessionBinding> _bindings = [];
@@ -175,6 +195,16 @@ internal sealed class GsmtcBackend : IMediaBackend
         foreach (var binding in bindings)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (binding.IsMissing)
+            {
+                snapshots.Add(
+                    (binding.LastSnapshot ?? CreateFallbackSnapshot(binding)) with
+                    {
+                        IsAvailable = false,
+                    });
+                continue;
+            }
+
             var plan = binding.BeginObservation();
             if (plan.Changes == SessionObservationChanges.None)
             {
@@ -254,12 +284,14 @@ internal sealed class GsmtcBackend : IMediaBackend
             this._bindings.TryGetValue(command.SessionId, out target);
             sessionsToPause = command.SessionsToPause
                 .Select(id => this._bindings.GetValueOrDefault(id))
-                .Where(static binding => binding is not null)
+                .Where(static binding => binding is { IsMissing: false })
                 .Cast<SessionBinding>()
                 .ToArray();
         }
 
-        if (target is null || target.Generation != command.BindingGeneration)
+        if (target is null ||
+            target.IsMissing ||
+            target.Generation != command.BindingGeneration)
         {
             return new(MediaBackendCommandStatus.SessionGone, "The target session was replaced or removed.");
         }
@@ -379,6 +411,7 @@ internal sealed class GsmtcBackend : IMediaBackend
             this._manager = null;
             bindings = [.. this._bindings.Values];
             this._bindings.Clear();
+            this._recentlyRemovedBindings.Clear();
             this._currentSessionId = null;
         }
 
@@ -898,12 +931,16 @@ internal sealed class GsmtcBackend : IMediaBackend
     {
         GlobalSystemMediaTransportControlsSessionManager manager;
         SessionBinding[] existingBindings;
+        RecentSessionBinding[] recentBindings;
         lock (this._stateLock)
         {
             manager = this._manager ?? throw new InvalidOperationException("The GSMTC backend is not started.");
             existingBindings = [.. this._bindings.Values];
+            recentBindings = [.. this._recentlyRemovedBindings];
         }
 
+        var retentionsToSchedule = new List<(SessionBinding Binding, MissingSessionRetention Retention)>();
+        var recentCleanupsToSchedule = new List<RecentSessionBinding>();
         await this._controlGate.RunAsync(
             () =>
             {
@@ -913,26 +950,47 @@ internal sealed class GsmtcBackend : IMediaBackend
                 var currentCall = this.BeginManagerCall("GetCurrentSession");
                 var currentSession = manager.GetCurrentSession();
                 this.CompleteManagerCall("GetCurrentSession", currentCall);
-                var availableExisting = existingBindings.ToList();
-                var nextBindings = new Dictionary<MediaBackendSessionId, SessionBinding>();
-                var replacedBindings = new List<SessionBinding>();
+                var now = GsmtcUnbiasedClock.GetTime();
+                var observedSessions = new List<ObservedSession>(sessions.Count);
                 var addedCount = 0;
                 var retainedCount = 0;
                 var reboundCount = 0;
-
+                var removedCount = 0;
                 foreach (var session in sessions)
                 {
-                    string applicationId;
                     try
                     {
-                        applicationId = session.SourceAppUserModelId;
+                        observedSessions.Add(new(session, session.SourceAppUserModelId));
                     }
                     catch (Exception ex) when (GsmtcErrors.IndicatesStaleSession(ex))
                     {
-                        continue;
                     }
+                }
 
-                    var existing = FindExistingBinding(availableExisting, session, applicationId);
+                var observedApplicationCounts = observedSessions
+                    .GroupBy(static session => session.ApplicationId, StringComparer.Ordinal)
+                    .ToDictionary(static group => group.Key, static group => group.Count(), StringComparer.Ordinal);
+                var availableActive = existingBindings.ToList();
+                var availableRecent = recentBindings
+                    .Where(binding => binding.ExpiresAt > now)
+                    .ToList();
+                var availableCandidates = availableActive
+                    .Concat(availableRecent.Select(static binding => binding.Binding))
+                    .ToList();
+                var candidateApplicationCounts = availableCandidates
+                    .GroupBy(static binding => binding.ApplicationId, StringComparer.Ordinal)
+                    .ToDictionary(static group => group.Key, static group => group.Count(), StringComparer.Ordinal);
+                var nextBindings = new Dictionary<MediaBackendSessionId, SessionBinding>();
+
+                foreach (var observed in observedSessions)
+                {
+                    var applicationIsUnambiguous =
+                        observedApplicationCounts[observed.ApplicationId] == 1;
+                    var existing = FindExistingBinding(
+                        availableCandidates,
+                        observed.Session,
+                        observed.ApplicationId,
+                        applicationIsUnambiguous);
                     SessionBinding binding;
                     if (existing is null)
                     {
@@ -941,32 +999,102 @@ internal sealed class GsmtcBackend : IMediaBackend
                             this,
                             new(Interlocked.Increment(ref this._nextSessionId)),
                             1,
-                            applicationId,
-                            session);
+                            observed.ApplicationId,
+                            observed.Session);
                         binding.Hook();
-                    }
-                    else if (ReferenceEquals(existing.Session, session))
-                    {
-                        retainedCount++;
-                        binding = existing;
-                        availableExisting.Remove(existing);
                     }
                     else
                     {
-                        reboundCount++;
-                        binding = new(
-                            this,
-                            existing.Id,
-                            existing.Generation + 1,
-                            applicationId,
-                            session);
-                        binding.SeedSnapshot(existing.LastSnapshot);
-                        binding.Hook();
-                        availableExisting.Remove(existing);
-                        replacedBindings.Add(existing);
+                        var wasActive = availableActive.Remove(existing);
+                        var recentIndex = availableRecent.FindIndex(
+                            candidate => ReferenceEquals(candidate.Binding, existing));
+                        var wasRecent = recentIndex >= 0;
+                        if (wasRecent)
+                        {
+                            availableRecent.RemoveAt(recentIndex);
+                        }
+
+                        availableCandidates.Remove(existing);
+                        if (wasActive &&
+                            !existing.IsMissing &&
+                            ReferenceEquals(existing.Session, observed.Session))
+                        {
+                            retainedCount++;
+                            binding = existing;
+                        }
+                        else
+                        {
+                            reboundCount++;
+                            binding = new(
+                                this,
+                                existing.Id,
+                                existing.Generation + 1,
+                                observed.ApplicationId,
+                                observed.Session);
+                            binding.SeedSnapshot(existing.LastSnapshot);
+                            binding.Hook();
+                            existing.Unhook();
+
+                            var evidence = wasRecent
+                                ? SessionRecreationEvidence.Weak
+                                : SessionRecreationEvidence.Strong;
+                            if (this._sessionRetentionPolicy.RecordRecreation(
+                                observed.ApplicationId,
+                                evidence,
+                                existing.GetMissingDuration(now),
+                                now))
+                            {
+                                var gracePeriod = this._sessionRetentionPolicy.GetGracePeriod(
+                                    observed.ApplicationId,
+                                    now,
+                                    isUnambiguous: true);
+                                MediaLog.SessionRecreationGraceIncreased(
+                                    this._logger,
+                                    observed.ApplicationId,
+                                    gracePeriod);
+                            }
+                        }
                     }
 
                     nextBindings.Add(binding.Id, binding);
+                }
+
+                foreach (var missing in availableActive)
+                {
+                    if (!missing.IsMissing)
+                    {
+                        var isUnambiguous =
+                            candidateApplicationCounts.GetValueOrDefault(missing.ApplicationId) == 1 &&
+                            observedApplicationCounts.GetValueOrDefault(missing.ApplicationId) == 0;
+                        var gracePeriod = this._sessionRetentionPolicy.GetGracePeriod(
+                            missing.ApplicationId,
+                            now,
+                            isUnambiguous);
+                        var retention = missing.BeginMissingRetention(
+                            now,
+                            now + gracePeriod);
+                        missing.Unhook();
+                        retentionsToSchedule.Add((missing, retention));
+                        MediaLog.SessionRetentionStarted(
+                            this._logger,
+                            missing.ApplicationId,
+                            gracePeriod);
+                    }
+
+                    if (!missing.IsRemovalDue)
+                    {
+                        retainedCount++;
+                        nextBindings.Add(missing.Id, missing);
+                        continue;
+                    }
+
+                    removedCount++;
+                    var recent = new RecentSessionBinding(
+                        missing,
+                        now + this._sessionRetentionPolicy.RecentRemovalWindow);
+                    availableRecent.Add(recent);
+                    recentCleanupsToSchedule.Add(recent);
+                    MediaLog.SessionRetentionExpired(this._logger, missing.ApplicationId);
                 }
 
                 var currentSessionId = FindCurrentSessionId(nextBindings.Values, currentSession);
@@ -978,12 +1106,9 @@ internal sealed class GsmtcBackend : IMediaBackend
                         this._bindings.Add(id, binding);
                     }
 
+                    this._recentlyRemovedBindings.Clear();
+                    this._recentlyRemovedBindings.AddRange(availableRecent);
                     this._currentSessionId = currentSessionId;
-                }
-
-                foreach (var removed in availableExisting.Concat(replacedBindings))
-                {
-                    removed.Unhook();
                 }
 
                 MediaLog.SessionReconciliationCompleted(
@@ -993,24 +1118,41 @@ internal sealed class GsmtcBackend : IMediaBackend
                     addedCount,
                     retainedCount,
                     reboundCount,
-                    availableExisting.Count);
+                    removedCount);
 
                 return Task.FromResult(true);
             },
             "RefreshSessions",
             cancellationToken).ConfigureAwait(false);
+
+        var disposeToken = this._disposeCts.Token;
+        foreach (var (binding, retention) in retentionsToSchedule)
+        {
+            _ = this.ExpireRetentionAsync(binding, retention, disposeToken);
+        }
+
+        foreach (var recent in recentCleanupsToSchedule)
+        {
+            _ = this.ExpireRecentBindingAsync(recent, disposeToken);
+        }
     }
 
     private static SessionBinding? FindExistingBinding(
         IReadOnlyCollection<SessionBinding> existingBindings,
         GlobalSystemMediaTransportControlsSession session,
-        string applicationId)
+        string applicationId,
+        bool allowApplicationMatch)
     {
         var referenceMatch = existingBindings.FirstOrDefault(
             binding => ReferenceEquals(binding.Session, session));
         if (referenceMatch is not null)
         {
             return referenceMatch;
+        }
+
+        if (!allowApplicationMatch)
+        {
+            return null;
         }
 
         var applicationMatches = existingBindings
@@ -1021,6 +1163,86 @@ internal sealed class GsmtcBackend : IMediaBackend
             .Take(2)
             .ToArray();
         return applicationMatches.Length == 1 ? applicationMatches[0] : null;
+    }
+
+    private async Task ExpireRetentionAsync(
+        SessionBinding binding,
+        MissingSessionRetention retention,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (true)
+            {
+                var status = binding.TryExpireRetention(
+                    retention.Version,
+                    GsmtcUnbiasedClock.GetTime(),
+                    out var remaining);
+                if (status == RetentionExpiryStatus.Inactive)
+                {
+                    return;
+                }
+
+                if (status == RetentionExpiryStatus.Expired)
+                {
+                    break;
+                }
+
+                await Task.Delay(remaining, cancellationToken).ConfigureAwait(false);
+            }
+
+            var isCurrentBinding = false;
+            lock (this._stateLock)
+            {
+                isCurrentBinding = this._bindings.TryGetValue(binding.Id, out var current) &&
+                                   ReferenceEquals(current, binding);
+            }
+
+            if (isCurrentBinding)
+            {
+                this.InvalidateManagerState(
+                    ManagerChanges.All,
+                    MediaBackendSignal.SessionsChanged |
+                    MediaBackendSignal.CurrentSessionChanged);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task ExpireRecentBindingAsync(
+        RecentSessionBinding recent,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var remaining = recent.ExpiresAt - GsmtcUnbiasedClock.GetTime();
+            while (remaining > TimeSpan.Zero)
+            {
+                await Task.Delay(remaining, cancellationToken).ConfigureAwait(false);
+                remaining = recent.ExpiresAt - GsmtcUnbiasedClock.GetTime();
+            }
+
+            var isCurrentTombstone = false;
+            lock (this._stateLock)
+            {
+                isCurrentTombstone = this._recentlyRemovedBindings.Any(
+                    candidate =>
+                        ReferenceEquals(candidate.Binding, recent.Binding) &&
+                        candidate.ExpiresAt == recent.ExpiresAt);
+            }
+
+            if (isCurrentTombstone)
+            {
+                this.InvalidateManagerState(
+                    ManagerChanges.Sessions,
+                    MediaBackendSignal.ObservationsChanged);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
     }
 
     private static MediaBackendSessionId? FindCurrentSessionId(
@@ -1131,9 +1353,15 @@ internal sealed class GsmtcBackend : IMediaBackend
         private readonly Lock _stateLock = new();
         private IRandomAccessStreamReference? _artworkReference;
         private bool _artworkChanged = true;
+        private int _isHooked;
+        private bool _isMissing;
+        private TimeSpan _missingSince;
         private long _artworkVersion;
         private MediaBackendSessionSnapshot? _lastSnapshot;
         private SessionObservationChanges _pendingChanges = SessionObservationChanges.All;
+        private bool _removalDue;
+        private TimeSpan _retentionDeadline;
+        private long _retentionVersion;
 
         public MediaBackendSessionId Id { get; } = id;
 
@@ -1142,6 +1370,28 @@ internal sealed class GsmtcBackend : IMediaBackend
         public string ApplicationId { get; } = applicationId;
 
         public GlobalSystemMediaTransportControlsSession Session { get; } = session;
+
+        public bool IsMissing
+        {
+            get
+            {
+                lock (this._stateLock)
+                {
+                    return this._isMissing;
+                }
+            }
+        }
+
+        public bool IsRemovalDue
+        {
+            get
+            {
+                lock (this._stateLock)
+                {
+                    return this._removalDue;
+                }
+            }
+        }
 
         public MediaBackendSessionSnapshot? LastSnapshot
         {
@@ -1199,6 +1449,65 @@ internal sealed class GsmtcBackend : IMediaBackend
             }
         }
 
+        public MissingSessionRetention BeginMissingRetention(
+            TimeSpan missingSince,
+            TimeSpan deadline)
+        {
+            lock (this._stateLock)
+            {
+                if (this._isMissing)
+                {
+                    throw new InvalidOperationException("The session is already being retained as missing.");
+                }
+
+                this._isMissing = true;
+                this._missingSince = missingSince;
+                this._removalDue = false;
+                this._retentionDeadline = deadline;
+                this._retentionVersion++;
+                return new(this._retentionVersion);
+            }
+        }
+
+        public TimeSpan? GetMissingDuration(TimeSpan now)
+        {
+            lock (this._stateLock)
+            {
+                if (!this._isMissing)
+                {
+                    return null;
+                }
+
+                var duration = now - this._missingSince;
+                return duration > TimeSpan.Zero ? duration : TimeSpan.Zero;
+            }
+        }
+
+        public RetentionExpiryStatus TryExpireRetention(
+            long version,
+            TimeSpan now,
+            out TimeSpan remaining)
+        {
+            lock (this._stateLock)
+            {
+                if (!this._isMissing || version != this._retentionVersion)
+                {
+                    remaining = TimeSpan.Zero;
+                    return RetentionExpiryStatus.Inactive;
+                }
+
+                remaining = this._retentionDeadline - now;
+                if (remaining > TimeSpan.Zero)
+                {
+                    return RetentionExpiryStatus.Waiting;
+                }
+
+                this._removalDue = true;
+                remaining = TimeSpan.Zero;
+                return RetentionExpiryStatus.Expired;
+            }
+        }
+
         public MediaArtworkKey? UpdateArtworkReference(
             IRandomAccessStreamReference? reference)
         {
@@ -1232,7 +1541,8 @@ internal sealed class GsmtcBackend : IMediaBackend
         {
             lock (this._stateLock)
             {
-                if (version == this._artworkVersion &&
+                if (!this._isMissing &&
+                    version == this._artworkVersion &&
                     this._artworkReference is { } current)
                 {
                     reference = current;
@@ -1246,6 +1556,11 @@ internal sealed class GsmtcBackend : IMediaBackend
 
         public void Hook()
         {
+            if (Interlocked.Exchange(ref this._isHooked, 1) != 0)
+            {
+                return;
+            }
+
             this.Session.PlaybackInfoChanged += this.SessionOnPlaybackInfoChanged;
             this.Session.MediaPropertiesChanged += this.SessionOnMediaPropertiesChanged;
             this.Session.TimelinePropertiesChanged += this.SessionOnTimelinePropertiesChanged;
@@ -1253,6 +1568,11 @@ internal sealed class GsmtcBackend : IMediaBackend
 
         public void Unhook()
         {
+            if (Interlocked.Exchange(ref this._isHooked, 0) == 0)
+            {
+                return;
+            }
+
             this.Session.PlaybackInfoChanged -= this.SessionOnPlaybackInfoChanged;
             this.Session.MediaPropertiesChanged -= this.SessionOnMediaPropertiesChanged;
             this.Session.TimelinePropertiesChanged -= this.SessionOnTimelinePropertiesChanged;

--- a/src/MediaControlsExtension.Media/Infrastructure/IMediaBackend.cs
+++ b/src/MediaControlsExtension.Media/Infrastructure/IMediaBackend.cs
@@ -46,7 +46,8 @@ internal sealed record MediaBackendSessionSnapshot(
     MediaPropertiesSnapshot MediaProperties,
     MediaTimelinePropertiesSnapshot TimelineProperties,
     MediaPlaybackState PlaybackState,
-    MediaCapabilities Capabilities);
+    MediaCapabilities Capabilities,
+    bool IsAvailable = true);
 
 internal sealed record MediaBackendSnapshot(
     long Revision,

--- a/src/MediaControlsExtension.Media/State/MediaStateStore.cs
+++ b/src/MediaControlsExtension.Media/State/MediaStateStore.cs
@@ -59,6 +59,7 @@ internal sealed class MediaStateStore
         lock (this._stateLock)
         {
             var liveSessionIds = backendSnapshot.Sessions
+                .Where(static session => session.IsAvailable)
                 .Select(static session => new MediaSessionId(session.Id.Value))
                 .ToHashSet();
             foreach (var removedId in this._pendingPlayback.Keys.Where(id => !liveSessionIds.Contains(id)).ToArray())
@@ -91,6 +92,7 @@ internal sealed class MediaStateStore
                 sessions.Add(new(
                     sessionId,
                     backendSession.BindingGeneration,
+                    backendSession.IsAvailable,
                     backendSession.MediaProperties,
                     backendSession.TimelineProperties,
                     new(
@@ -171,6 +173,11 @@ internal sealed class MediaStateStore
             }
 
             var target = this._current.Sessions[targetIndex];
+            if (!target.IsAvailable)
+            {
+                return MediaCommandSubmissionStatus.SessionGone;
+            }
+
             if (operation == MediaOperation.TogglePlayback)
             {
                 operation = target.PlaybackInfo.PrimaryOperation;

--- a/src/MediaControlsExtension/Commands/MediaOps/MediaSessionOp.cs
+++ b/src/MediaControlsExtension/Commands/MediaOps/MediaSessionOp.cs
@@ -11,7 +11,7 @@ internal abstract class MediaSessionOp
 {
     public abstract MediaOperation Operation { get; }
 
-    public virtual bool CanExecute(MediaSession session) => true;
+    public virtual bool CanExecute(MediaSession session) => session.IsAvailable;
 
     public async Task<string?> InvokeAsync(
         IMediaService mediaService,

--- a/src/MediaControlsExtension/Commands/MediaOps/SkipNextTrackMop.cs
+++ b/src/MediaControlsExtension/Commands/MediaOps/SkipNextTrackMop.cs
@@ -12,6 +12,7 @@ internal sealed class SkipNextTrackMop : MediaSessionOp
     public override MediaOperation Operation => MediaOperation.SkipNext;
 
     public override bool CanExecute(MediaSession session) =>
+        session.IsAvailable &&
         session.PlaybackInfo.Capabilities.HasFlag(MediaCapabilities.SkipNext);
 
     protected override ValueTask<string> GetSuccessMessageAsync(

--- a/src/MediaControlsExtension/Commands/MediaOps/SkipPreviousTrackMop.cs
+++ b/src/MediaControlsExtension/Commands/MediaOps/SkipPreviousTrackMop.cs
@@ -12,6 +12,7 @@ internal sealed class SkipPreviousTrackMop : MediaSessionOp
     public override MediaOperation Operation => MediaOperation.SkipPrevious;
 
     public override bool CanExecute(MediaSession session) =>
+        session.IsAvailable &&
         session.PlaybackInfo.Capabilities.HasFlag(MediaCapabilities.SkipPrevious);
 
     protected override ValueTask<string> GetSuccessMessageAsync(

--- a/src/MediaControlsExtension/Commands/MediaOps/ToggleRepeatMop.cs
+++ b/src/MediaControlsExtension/Commands/MediaOps/ToggleRepeatMop.cs
@@ -12,6 +12,7 @@ internal sealed class ToggleRepeatMop : MediaSessionOp
     public override MediaOperation Operation => MediaOperation.ToggleRepeat;
 
     public override bool CanExecute(MediaSession session) =>
+        session.IsAvailable &&
         session.PlaybackInfo.Capabilities.HasFlag(MediaCapabilities.ToggleRepeat);
 
     protected override ValueTask<string> GetSuccessMessageAsync(

--- a/src/MediaControlsExtension/Commands/MediaOps/ToggleShuffleMop.cs
+++ b/src/MediaControlsExtension/Commands/MediaOps/ToggleShuffleMop.cs
@@ -12,6 +12,7 @@ internal sealed class ToggleShuffleMop : MediaSessionOp
     public override MediaOperation Operation => MediaOperation.ToggleShuffle;
 
     public override bool CanExecute(MediaSession session) =>
+        session.IsAvailable &&
         session.PlaybackInfo.Capabilities.HasFlag(MediaCapabilities.ToggleShuffle);
 
     protected override ValueTask<string> GetSuccessMessageAsync(

--- a/src/MediaControlsExtension/Commands/OptimisticPlaybackCommand.cs
+++ b/src/MediaControlsExtension/Commands/OptimisticPlaybackCommand.cs
@@ -64,6 +64,7 @@ internal sealed partial class OptimisticPlaybackCommand : AsyncInvokableCommand
         lock (this._presentationLock)
         {
             this._target = target is null
+                || !target.IsAvailable
                 ? null
                 : new(
                     target.Id,

--- a/tests/MediaControlsExtension.Media.Tests/AdaptiveSessionRetentionPolicyTests.cs
+++ b/tests/MediaControlsExtension.Media.Tests/AdaptiveSessionRetentionPolicyTests.cs
@@ -1,0 +1,165 @@
+// ------------------------------------------------------------
+//
+// Copyright (c) Jiří Polášek. All rights reserved.
+//
+// ------------------------------------------------------------
+
+using JPSoftworks.MediaControlsExtension.Media.Infrastructure.Gsmtc;
+
+namespace JPSoftworks.MediaControlsExtension.Media.Tests;
+
+[TestClass]
+public sealed class AdaptiveSessionRetentionPolicyTests
+{
+    private static readonly TimeSpan ProbeGracePeriod = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan MaximumGracePeriod = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan RecentRemovalWindow = TimeSpan.FromSeconds(4);
+    private static readonly TimeSpan EvidenceLifetime = TimeSpan.FromMinutes(5);
+
+    [TestMethod]
+    public void UnknownApplicationUsesProbeGracePeriod()
+    {
+        var policy = CreatePolicy();
+
+        var gracePeriod = policy.GetGracePeriod("browser", TimeSpan.Zero, isUnambiguous: true);
+
+        Assert.AreEqual(ProbeGracePeriod, gracePeriod);
+        Assert.AreEqual(RecentRemovalWindow, policy.RecentRemovalWindow);
+    }
+
+    [TestMethod]
+    public void StrongRecreationWithoutMissingIntervalKeepsProbeGracePeriod()
+    {
+        var policy = CreatePolicy();
+
+        var graceIncreased = policy.RecordRecreation(
+            "browser",
+            SessionRecreationEvidence.Strong,
+            missingDuration: null,
+            TimeSpan.FromSeconds(1));
+
+        Assert.IsFalse(graceIncreased);
+        Assert.AreEqual(
+            ProbeGracePeriod,
+            policy.GetGracePeriod("browser", TimeSpan.FromSeconds(2), isUnambiguous: true));
+    }
+
+    [TestMethod]
+    public void TwoWeakRecreationsUseLargestObservedMissingInterval()
+    {
+        var policy = CreatePolicy();
+
+        Assert.IsFalse(policy.RecordRecreation(
+            "browser",
+            SessionRecreationEvidence.Weak,
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(1)));
+        Assert.AreEqual(
+            ProbeGracePeriod,
+            policy.GetGracePeriod("browser", TimeSpan.FromSeconds(2), isUnambiguous: true));
+
+        Assert.IsTrue(policy.RecordRecreation(
+            "browser",
+            SessionRecreationEvidence.Weak,
+            TimeSpan.FromMilliseconds(800),
+            TimeSpan.FromSeconds(3)));
+        Assert.AreEqual(
+            TimeSpan.FromMilliseconds(1500),
+            policy.GetGracePeriod("browser", TimeSpan.FromSeconds(4), isUnambiguous: true));
+    }
+
+    [TestMethod]
+    public void LearnedDirectReplacementUsesLaterObservedMissingInterval()
+    {
+        var policy = CreatePolicy();
+        policy.RecordRecreation(
+            "browser",
+            SessionRecreationEvidence.Strong,
+            missingDuration: null,
+            TimeSpan.Zero);
+
+        policy.RecordRecreation(
+            "browser",
+            SessionRecreationEvidence.Weak,
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(2));
+
+        Assert.AreEqual(
+            TimeSpan.FromMilliseconds(1500),
+            policy.GetGracePeriod("browser", TimeSpan.FromSeconds(3), isUnambiguous: true));
+    }
+
+    [TestMethod]
+    public void ObservedMissingDurationGrowsLearnedGraceWithMargin()
+    {
+        var policy = CreatePolicy();
+
+        policy.RecordRecreation(
+            "browser",
+            SessionRecreationEvidence.Strong,
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(2));
+
+        Assert.AreEqual(
+            TimeSpan.FromMilliseconds(1500),
+            policy.GetGracePeriod("browser", TimeSpan.FromSeconds(3), isUnambiguous: true));
+    }
+
+    [TestMethod]
+    public void ObservedMissingDurationIsCappedAtMaximumGracePeriod()
+    {
+        var policy = CreatePolicy();
+
+        policy.RecordRecreation(
+            "browser",
+            SessionRecreationEvidence.Strong,
+            TimeSpan.FromSeconds(3),
+            TimeSpan.FromSeconds(2));
+
+        Assert.AreEqual(
+            MaximumGracePeriod,
+            policy.GetGracePeriod("browser", TimeSpan.FromSeconds(3), isUnambiguous: true));
+    }
+
+    [TestMethod]
+    public void LearnedGraceIsNotUsedForAmbiguousApplicationSessions()
+    {
+        var policy = CreatePolicy();
+        policy.RecordRecreation(
+            "browser",
+            SessionRecreationEvidence.Strong,
+            missingDuration: null,
+            TimeSpan.Zero);
+
+        var gracePeriod = policy.GetGracePeriod(
+            "browser",
+            TimeSpan.FromSeconds(1),
+            isUnambiguous: false);
+
+        Assert.AreEqual(ProbeGracePeriod, gracePeriod);
+    }
+
+    [TestMethod]
+    public void LearnedEvidenceExpiresAfterQuietPeriod()
+    {
+        var policy = CreatePolicy();
+        policy.RecordRecreation(
+            "browser",
+            SessionRecreationEvidence.Strong,
+            missingDuration: null,
+            TimeSpan.Zero);
+
+        var gracePeriod = policy.GetGracePeriod(
+            "browser",
+            EvidenceLifetime,
+            isUnambiguous: true);
+
+        Assert.AreEqual(ProbeGracePeriod, gracePeriod);
+    }
+
+    private static AdaptiveSessionRetentionPolicy CreatePolicy() => new(
+        ProbeGracePeriod,
+        MaximumGracePeriod,
+        RecentRemovalWindow,
+        EvidenceLifetime);
+}

--- a/tests/MediaControlsExtension.Media.Tests/MediaServiceConcurrencyTests.cs
+++ b/tests/MediaControlsExtension.Media.Tests/MediaServiceConcurrencyTests.cs
@@ -279,6 +279,62 @@ public sealed class MediaServiceConcurrencyTests
     }
 
     [TestMethod]
+    public async Task RetainedUnavailableSessionKeepsIdentityAndRejectsCommandsUntilRebound()
+    {
+        var initialSnapshot = FakeMediaBackend.CreateSnapshot(1, "Initial");
+        var backend = new FakeMediaBackend(initialSnapshot);
+        await using var service = new MediaService(backend);
+        await service.StartAsync();
+
+        var session = service.CurrentSession;
+        Assert.IsNotNull(session);
+        var becameUnavailable = new TaskCompletionSource<MediaSessionChangedEventArgs>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var becameAvailable = new TaskCompletionSource<MediaSessionChangedEventArgs>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        session.Changed += (_, args) =>
+        {
+            if (!session.IsAvailable)
+            {
+                becameUnavailable.TrySetResult(args);
+            }
+            else if (args.Changes.HasFlag(MediaSessionChanges.Rebound))
+            {
+                becameAvailable.TrySetResult(args);
+            }
+        };
+
+        backend.SetSnapshot(initialSnapshot with
+        {
+            Revision = 2,
+            Sessions = [initialSnapshot.Sessions[0] with { IsAvailable = false }],
+            CurrentSessionId = null,
+        });
+
+        var unavailableArgs = await becameUnavailable.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.AreEqual(MediaSessionChanges.Availability, unavailableArgs.Changes);
+        Assert.AreSame(session, service.Sessions.Single());
+        Assert.IsNull(service.CurrentSession);
+        Assert.AreEqual(
+            MediaCommandSubmissionStatus.SessionGone,
+            service.TrySubmit(new(
+                MediaCommandTarget.ForSession(session.Id),
+                MediaOperation.Play)).Status);
+
+        backend.SetSnapshot(FakeMediaBackend.CreateSnapshot(
+            3,
+            "Initial",
+            bindingGeneration: 2));
+
+        var availableArgs = await becameAvailable.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.IsTrue(availableArgs.Changes.HasFlag(MediaSessionChanges.Availability));
+        Assert.IsTrue(availableArgs.Changes.HasFlag(MediaSessionChanges.Rebound));
+        Assert.IsTrue(session.IsAvailable);
+        Assert.AreSame(session, service.CurrentSession);
+        Assert.AreSame(session, service.Sessions.Single());
+    }
+
+    [TestMethod]
     public async Task CurrentSessionChangedReportsTheLatestCurrentSession()
     {
         var backend = new FakeMediaBackend(FakeMediaBackend.CreateSnapshot(


### PR DESCRIPTION
Retain temporarily unavailable sessions to preserve UI identity and selection. Learn longer per-app grace periods only from measured recreation gaps while keeping normal app removal responsive.

Fixes: #40