### PR TITLE
Release 0.22.0 servicing update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Media Controls for Command Palette are documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 -->
 
+## [0.22.0] - 2026-08-17
+
+This is a servicing update for the 0.20 release.
+
+### Fixed
+
+- **Media session stability** - hardened GSMTC object lifetimes, command execution, cleanup, and failed-session retirement to avoid crashes originating inside Windows media APIs. ([#49](https://github.com/jiripolasek/MediaControlsExtension/pull/49))
+- **Media app discovery stability** - failed cross-process application identity lookups no longer escape through unmanaged window-enumeration callbacks. ([#46](https://github.com/jiripolasek/MediaControlsExtension/pull/46))
+
 ## [0.20.0] - 2026-08-04
 
 ### Added

--- a/src/MediaControlsExtension.Package/Package.appxmanifest
+++ b/src/MediaControlsExtension.Package/Package.appxmanifest
@@ -12,7 +12,7 @@
   <Identity
     Name="JiriPolasek.MediaControlsForCmdPal"
     Publisher="CN=735F2779-478E-4220-AA28-465CBADFF852"
-    Version="0.20.1000.0" />
+    Version="0.22.0.0" />
   <!-- When you're ready to publish your extension, you'll need to change the
        Publisher= to match your own identity -->
 


### PR DESCRIPTION
## Summary

- Bumps the package version from `0.20.1000.0` to `0.22.0.0`.
- Adds the 0.22.0 changelog section for the servicing fixes delivered by #46 and #49.